### PR TITLE
Lazier init for easier repl, don't reset DB on every change

### DIFF
--- a/src/com/yetanalytics/lrs_admin_ui/core.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/core.cljs
@@ -14,10 +14,12 @@
 
 (defn mount-app-element []
   (when-let [el (gdom/getElement "app")]
-    (dispatch-sync [:db/init])
     (mount el)))
 
-(mount-app-element)
+(defonce init
+  (do
+    (dispatch-sync [:db/init])
+    (mount-app-element)))
 
 (defn ^:after-load on-reload []
   (mount-app-element))


### PR DESCRIPTION
* Wrap figwheel init in a defonce
* Don't couple `:db/init` with render, thus preserving db state on figwheel loads (refresh for re-init). This is more idiomatic re-frame + figwheel usage