### PR TITLE
sql-66 - frontend tweaks

### DIFF
--- a/resources/sass/global.scss
+++ b/resources/sass/global.scss
@@ -1129,6 +1129,12 @@ li.password-note {
   font-style: italic;
 }
 
+a.confirm-delete {
+  padding: 4px !important;
+  margin: 4px 0px 4px 25px;
+  border: 1px solid;
+}
+
 
 /**************************************************
 # Roles

--- a/resources/sass/global.scss
+++ b/resources/sass/global.scss
@@ -1123,6 +1123,12 @@ input.new-account {
 
 }
 
+li.password-note {
+  display: block;
+  font-size: .9em;
+  font-style: italic;
+}
+
 
 /**************************************************
 # Roles

--- a/src/com/yetanalytics/lrs_admin_ui/functions/copy.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/functions/copy.cljs
@@ -2,7 +2,8 @@
   (:require [reagent.core :as r]
             ["react-copy-to-clipboard" :refer [CopyToClipboard]]))
 
-(defn copy-text [{:keys [text]} element]
+(defn copy-text [{:keys [text on-copy]} element]
   [(r/adapt-react-class CopyToClipboard)
-   {:text text}
+   {:text text
+    :on-copy on-copy}
    element])

--- a/src/com/yetanalytics/lrs_admin_ui/views/accounts.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/accounts.cljs
@@ -6,17 +6,32 @@
    [com.yetanalytics.lrs-admin-ui.functions.copy :refer [copy-text]]))
 
 (defn account [{{:keys [account-id username] :as account} :account}]
-  [:li {:class "mb-2"}
-   [:div {:class "accordion-container"}
-    [:div {:class "account-row"}
-     [:div {:class "account-col"}
-      [:p username]]
-     [:div {:class "account-col"}
-      [:ul {:class "action-icon-list"}
-       [:li
-        [:a {:href "#!",
-             :on-click #(dispatch [:accounts/delete-account account])
-             :class "icon-delete"} "Delete"]]]]]]])
+  (let [delete-confirm (r/atom false)]
+    (fn []
+      [:li {:class "mb-2"}
+       [:div {:class "accordion-container"}
+        [:div {:class "account-row"}
+         [:div {:class "account-col"}
+          [:p username]]
+         [:div {:class "account-col"}
+          [:ul {:class "action-icon-list"}
+           (if @delete-confirm
+             [:li
+              [:span "Are you sure?"]
+              [:a {:href "#!",
+                   :on-click #(do (dispatch [:accounts/delete-account account])
+                                  (swap! delete-confirm not))
+                   :class "confirm-delete"}
+               "Yes"]
+              [:a {:href "#!"
+                   :on-click #(swap! delete-confirm not)
+                   :class "confirm-delete"}
+               "No"]]
+             [:li
+              [:a {:href "#!"
+                   :on-click #(swap! delete-confirm not)
+                   :class "icon-delete"}
+               "Delete"]])]]]]])))
 
 (defn new-account []
   (let [hide-pass (r/atom true)]

--- a/src/com/yetanalytics/lrs_admin_ui/views/accounts.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/accounts.cljs
@@ -47,14 +47,18 @@
                     :else "Hide"))]]
            [:li
             [copy-text
-             {:text (:password new-account)}
+             {:text (:password new-account)
+              :on-copy #(dispatch [:notification/notify false
+                                   "Copied New Password!"])}
              [:a {:class "icon-copy pointer"} "Copy"]]]]]
          [:div {:class "row"}
           [:ul {:class "action-icon-list"}
            [:li
             [:a {:href "#!",
                  :on-click #(dispatch [:new-account/generate-password])
-                 :class "icon-gen"} [:i "Generate Password"]]]]]]))))
+                 :class "icon-gen"} [:i "Generate Password"]]]
+           [:li {:class "password-note"}
+            "Be sure to note or copy the new password as it will not be accessible after creation."]]]]))))
 
 (defn accounts []
   (dispatch [:accounts/load-accounts])

--- a/src/com/yetanalytics/lrs_admin_ui/views/browser.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/browser.cljs
@@ -3,8 +3,7 @@
    [re-frame.core :refer [subscribe dispatch]]
    [com.yetanalytics.lrs-admin-ui.functions :as fns]
    [com.yetanalytics.lrs-admin-ui.functions.http :as httpfn]
-   [clojure.string :refer [blank?]]
-   [clojure.pprint :refer [pprint]]))
+   [clojure.string :refer [blank?]]))
 
 ;; Credential scopes to allow the browser to use (those which can read)
 (def read-scopes #{"all" "all/read" "statements/read"})

--- a/src/com/yetanalytics/lrs_admin_ui/views/browser.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/browser.cljs
@@ -3,7 +3,8 @@
    [re-frame.core :refer [subscribe dispatch]]
    [com.yetanalytics.lrs-admin-ui.functions :as fns]
    [com.yetanalytics.lrs-admin-ui.functions.http :as httpfn]
-   [clojure.string :refer [blank?]]))
+   [clojure.string :refer [blank?]]
+   [clojure.pprint :refer [pprint]]))
 
 (defn process-click
   "Extract the pertinent parts of an element from an event and instrument links
@@ -20,7 +21,11 @@
 
 (defn browser []
   (let [content @(subscribe [:browser/get-content])
-        credentials @(subscribe [:db/get-credentials])]
+        credentials @(subscribe [:db/get-credentials])
+        ;;filter out credentials that can't read the LRS
+        read-credentials (filter #(some #{"all" "all/read" "statements/read"}
+                                        (:scopes %))
+                                 credentials)]
     [:div {:class "left-content-wrapper"}
      [:h2 {:class "content-title"}
       "Data Browser"]
@@ -36,7 +41,7 @@
            [:option {:value (:api-key credential)
                      :key (str "browser-credential-" idx)}
             (fns/elide (:api-key credential) 20)])
-         credentials)]
+         read-credentials)]
        ]]
      (let [address @(subscribe [:browser/get-address])]
        (when (some? address)

--- a/src/com/yetanalytics/lrs_admin_ui/views/browser.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/browser.cljs
@@ -6,6 +6,9 @@
    [clojure.string :refer [blank?]]
    [clojure.pprint :refer [pprint]]))
 
+;; Credential scopes to allow the browser to use (those which can read)
+(def read-scopes #{"all" "all/read" "statements/read"})
+
 (defn process-click
   "Extract the pertinent parts of an element from an event and instrument links
   with appropriate dispatch. ignore non-links and external links"
@@ -21,11 +24,9 @@
 
 (defn browser []
   (let [content @(subscribe [:browser/get-content])
-        credentials @(subscribe [:db/get-credentials])
         ;;filter out credentials that can't read the LRS
-        read-credentials (filter #(some #{"all" "all/read" "statements/read"}
-                                        (:scopes %))
-                                 credentials)]
+        read-credentials (filter #(some read-scopes (:scopes %))
+                                 @(subscribe [:db/get-credentials]))]
     [:div {:class "left-content-wrapper"}
      [:h2 {:class "content-title"}
       "Data Browser"]

--- a/src/com/yetanalytics/lrs_admin_ui/views/credentials/api_key.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/credentials/api_key.cljs
@@ -19,7 +19,8 @@
   [{:keys [idx]}]
   (let [expanded (r/atom false)
         show-secret (r/atom false)
-        edit (r/atom false)]
+        edit (r/atom false)
+        delete-confirm (r/atom false)]
     (fn []
       (let [credential    @(subscribe [:credentials/get-credential idx])
             scopes        (:scopes credential)
@@ -113,7 +114,20 @@
                    [:a {:href "#!",
                         :on-click #(swap! edit not)
                         :class "icon-edit"} "Edit"]]
-                  [:li
-                   [:a {:href "#!",
-                        :on-click #(dispatch [:credentials/delete-credential credential])
-                        :class "icon-delete"} "Delete"]]]])]])]]))))
+                  (if @delete-confirm
+                    [:li
+                     [:span "Are you sure?"]
+                     [:a {:href "#!",
+                          :on-click #(do (dispatch [:credentials/delete-credential credential])
+                                         (swap! delete-confirm not))
+                          :class "confirm-delete"}
+                      "Yes"]
+                     [:a {:href "#!"
+                          :on-click #(swap! delete-confirm not)
+                          :class "confirm-delete"}
+                      "No"]]
+                    [:li
+                     [:a {:href "#!"
+                          :on-click #(swap! delete-confirm not)
+                          :class "icon-delete"}
+                      "Delete"]])]])]])]]))))

--- a/src/com/yetanalytics/lrs_admin_ui/views/credentials/api_key.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/credentials/api_key.cljs
@@ -21,8 +21,14 @@
         show-secret (r/atom false)
         edit (r/atom false)]
     (fn []
-      (let [credential @(subscribe [:credentials/get-credential idx])
-            scopes     (:scopes credential)]
+      (let [credential    @(subscribe [:credentials/get-credential idx])
+            scopes        (:scopes credential)
+            scope-display (map-indexed (fn [idx scope]
+                                         [:span {:key (str "scope-display-" idx)}
+                                          (str (when (> idx 0)
+                                                 ", ")
+                                               scope)])
+                                       scopes)]
         [:li {:class "mb-2"}
          [:div {:class "accordion-container"}
           [:div {:class "api-key-row"
@@ -39,13 +45,7 @@
                :on-copy #(dispatch [:notification/notify false "Copied API Key!"])}
               [:a {:class "icon-copy"
                    :on-click #(ps-event %)}]]]]
-           [:div {:class "api-key-col"} "Permissions: "
-            (map-indexed (fn [idx scope]
-                           [:span {:key (str "scope-display-" idx)}
-                            (str (when (> idx 0)
-                                   ", ")
-                                 scope)])
-                         scopes)]]
+           [:div {:class "api-key-col"} "Permissions: " scope-display]]
           (when @expanded
             [:div {:class "api-key-expand"}
              [:div {:class "api-key-col"}
@@ -107,7 +107,7 @@
                 :else
                 [:div {:class "action-row"}
                  [:div {:class "action-label"}
-                  "All"]
+                  scope-display]
                  [:ul {:class "action-icon-list"}
                   [:li
                    [:a {:href "#!",

--- a/src/com/yetanalytics/lrs_admin_ui/views/credentials/api_key.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/credentials/api_key.cljs
@@ -2,7 +2,8 @@
   (:require
    [reagent.core :as r]
    [re-frame.core :as re-frame :refer [dispatch subscribe]]
-   [com.yetanalytics.lrs-admin-ui.functions.copy :refer [copy-text]]))
+   [com.yetanalytics.lrs-admin-ui.functions.copy :refer [copy-text]]
+   [com.yetanalytics.lrs-admin-ui.functions      :refer [ps-event]]))
 
 (defn has-scope
   [list scope]
@@ -36,7 +37,8 @@
              [copy-text
               {:text (:api-key credential)
                :on-copy #(dispatch [:notification/notify false "Copied API Key!"])}
-              [:a {:class "icon-copy"}]]]]
+              [:a {:class "icon-copy"
+                   :on-click #(ps-event %)}]]]]
            [:div {:class "api-key-col"} "Permissions: "
             (map-indexed (fn [idx scope]
                            [:span {:key (str "scope-display-" idx)}
@@ -59,7 +61,7 @@
                    [copy-text
                     {:text (:secret-key credential)
                      :on-copy #(dispatch [:notification/notify false "Copied Secret Key!"])}
-                    [:a {:class "icon-copy"}]]]])
+                    [:a {:class "icon-copy pointer"}]]]])
                [:ul {:class "action-icon-list"}
                 [:li
                  [:a {:href "#!",

--- a/src/com/yetanalytics/lrs_admin_ui/views/credentials/api_key.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/credentials/api_key.cljs
@@ -34,7 +34,8 @@
                       :class "key-display"
                       :read-only true}]
              [copy-text
-              {:text (:api-key credential)}
+              {:text (:api-key credential)
+               :on-copy #(dispatch [:notification/notify false "Copied API Key!"])}
               [:a {:class "icon-copy"}]]]]
            [:div {:class "api-key-col"} "Permissions: "
             (map-indexed (fn [idx scope]
@@ -56,7 +57,8 @@
                             :class "key-display"
                             :read-only true}]
                    [copy-text
-                    {:text (:secret-key credential)}
+                    {:text (:secret-key credential)
+                     :on-copy #(dispatch [:notification/notify false "Copied Secret Key!"])}
                     [:a {:class "icon-copy"}]]]])
                [:ul {:class "action-icon-list"}
                 [:li

--- a/src/com/yetanalytics/lrs_admin_ui/views/credentials/tenant.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/credentials/tenant.cljs
@@ -6,6 +6,11 @@
 (defn tenant []
   (let [credentials @(subscribe [:db/get-credentials])]
     [:div {:class "tenant-wrapper"}
+     [:div {:class "api-keys-table-actions"}
+      [:input {:type "button",
+               :class "btn-blue-bold",
+               :on-click #(dispatch [:credentials/create-credential {:scopes ["all"]}])
+               :value "ADD NEW CREDENTIALS"}]]
      [:div {:class "credential-details"}
       #_[:div {:class "tenant-title-wrapper"}
        [:span {:class "fg-secondary"} "Tenant: "]


### PR DESCRIPTION
**sql-89, sql-100, sql-90**. 
- Notices in place for copies
- Add Credential button duplicated up top
- Note about password.

Update: 
- **Added SQL-109** (copy icon pointer on secret)
- AND added a stopPropagation to apikey copy button
- **Added SQL-108** (Delete Confirmation Step for Accounts and Credentials)
- **Added SQL-91** - spec validation errors coming from server are covered up with specific messages in frontend for account creation and login. Mostly just for the case that someone forgets to type username or password altogether.

![Screen Shot 2021-09-22 at 3 29 13 PM](https://user-images.githubusercontent.com/54323005/134410295-1fd321cd-087d-41fb-98da-e54e393f3920.png)
![Screen Shot 2021-09-22 at 3 29 58 PM](https://user-images.githubusercontent.com/54323005/134410305-e0c031bc-5a7c-4bff-90c1-144189cf1f61.png)
![Screen Shot 2021-09-22 at 8 47 56 PM](https://user-images.githubusercontent.com/54323005/134440215-db4a2ccc-52ab-46b5-9efb-48c72bfbc581.png)
