### PR TITLE
Security webpack update Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,18 @@ resources/public/css/style.css: node_modules
 
 build-sass: resources/public/css/style.css
 
-target/public/cljs-out/prod-main.js: node_modules
+target/public/cljs-out/prod/main_bundle.js: node_modules
 	clojure -Mfig -m figwheel.main -O advanced -bo prod
 
 target/bundle/index.html:
 	mkdir -p target/bundle
 	cp resources/public/index_prod.html target/bundle/index.html
 
-target/bundle/main.js: target/public/cljs-out/prod-main.js
+target/bundle/main.js: target/public/cljs-out/prod/main_bundle.js
 	mkdir -p target/bundle
 	cp target/public/cljs-out/prod/main_bundle.js target/bundle/main.js
 
-target/bundle/css: build-sass
+target/bundle/css: resources/public/css/style.css
 	mkdir -p target/bundle
 	cp -r resources/public/css target/bundle/css
 


### PR DESCRIPTION
In the sec branch the bundle js copies from the new, correct location, but the makefile target specifies the old one. Also found a phony in a target dep, which as we've seen messes things up.