### PR TITLE
Improve password generator

### DIFF
--- a/src/com/yetanalytics/lrs_admin_ui/functions.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/functions.cljs
@@ -25,12 +25,32 @@
     text
     (str (subs text 0 (- len 3)) "...")))
 
+;; Character classes
+(def digit-chars (map char (range 48 58)))  ; 0-9
+(def upper-chars (map char (range 65 91)))  ; A-Z
+(def lower-chars (map char (range 97 123))) ; a-z
+(def special-chars (concat (map char (range 33 48))   ; !"#$%&'()*+,-./
+                           (map char (range 58 65))   ; :;<=>?@
+                           (map char (range 91 97))   ; [\]^_`
+                           (map char (range 123 127)) ; {|}~
+                           ))
+
 (defn pass-gen
-  "Given length generate a password with random letters numbers and specials"
+  "Given length `n`, generate a password with random uppercase and lowercase
+   letters, numbers, and specials. At least one of each character category will
+   be included in the generated password. Note that `n` should be at at least
+   4 or else undefined behavior will occur."
   [n]
-  (let [chars (map char (concat (range 48 57)
-                                (range 97 122)
-                                (range 65 90)
-                                [\! \? \#]))
-        password (take n (repeatedly #(rand-nth chars)))]
-    (reduce str password)))
+  (let [;; Password
+        dcount (inc (rand-int (- n 3)))
+        ucount (inc (rand-int (- n 2 dcount)))
+        lcount (inc (rand-int (- n 1 dcount ucount)))
+        scount (- n dcount ucount lcount)
+        ;; Password chars
+        nseq (take dcount (repeatedly (partial rand-nth digit-chars)))
+        useq (take ucount (repeatedly (partial rand-nth upper-chars)))
+        lseq (take lcount (repeatedly (partial rand-nth lower-chars)))
+        sseq (take scount (repeatedly (partial rand-nth special-chars)))]
+    (->> (concat nseq useq lseq sseq)
+         shuffle
+         (reduce str))))

--- a/src/com/yetanalytics/lrs_admin_ui/functions.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/functions.cljs
@@ -1,6 +1,5 @@
 (ns com.yetanalytics.lrs-admin-ui.functions
-  (:require [clojure.set :as cset]
-            [re-frame.core                    :refer [subscribe dispatch-sync]]
+  (:require [re-frame.core                    :refer [subscribe dispatch-sync]]
             [com.yetanalytics.lrs-admin-ui.db :as db]
             [clojure.pprint :refer [pprint]]))
 

--- a/src/com/yetanalytics/lrs_admin_ui/functions.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/functions.cljs
@@ -29,7 +29,7 @@
 (def digit-chars (map char (range 48 58)))  ; 0-9
 (def upper-chars (map char (range 65 91)))  ; A-Z
 (def lower-chars (map char (range 97 123))) ; a-z
-(def special-chars [\! \? \#])
+(def special-chars [\! \@ \# \$ \% \^ \& \* \_ \- \+ \= \?])
 
 (defn pass-gen
   "Given length `n`, generate a password with random uppercase and lowercase

--- a/src/com/yetanalytics/lrs_admin_ui/functions.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/functions.cljs
@@ -1,5 +1,6 @@
 (ns com.yetanalytics.lrs-admin-ui.functions
-  (:require [re-frame.core                    :refer [subscribe dispatch-sync]]
+  (:require [clojure.set :as cset]
+            [re-frame.core                    :refer [subscribe dispatch-sync]]
             [com.yetanalytics.lrs-admin-ui.db :as db]
             [clojure.pprint :refer [pprint]]))
 
@@ -29,11 +30,7 @@
 (def digit-chars (map char (range 48 58)))  ; 0-9
 (def upper-chars (map char (range 65 91)))  ; A-Z
 (def lower-chars (map char (range 97 123))) ; a-z
-(def special-chars (concat (map char (range 33 48))   ; !"#$%&'()*+,-./
-                           (map char (range 58 65))   ; :;<=>?@
-                           (map char (range 91 97))   ; [\]^_`
-                           (map char (range 123 127)) ; {|}~
-                           ))
+(def special-chars [\! \? \#])
 
 (defn pass-gen
   "Given length `n`, generate a password with random uppercase and lowercase


### PR DESCRIPTION
Improve password generators such that generated passwords have at least one uppercase letter, lowercase letter, digit, and special character. Also fix an off-by-one error preventing `9`, `Z`, and `z` from appearing in generated passwords.