### PR TITLE
Enable Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'v*.*.*' # Enforce Semantic Versioning
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Java
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@3.5
+      with:
+        cli: 1.10.3.943
+
+    - name: Build Bundle
+      run: make bundle
+
+    - name: Compress Bundle
+      run: | # Need to cd so that the zip file doesn't contain the parent dirs
+        cd target/bundle
+        zip -r ../../lrs-admin-ui.zip ./
+
+    - name: Archive Bundle (Branch Pushes)
+      if: ${{ startsWith(github.ref, 'refs/heads') }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: lrs-admin-ui-artifact-${{ github.sha }}
+        path: lrs-admin-ui.zip
+
+    - name: Craft Draft Release (Tag Pushes)
+      if: ${{ startsWith(github.ref, 'refs/tags') }}
+      uses: softprops/action-gh-release@v1
+      with:
+        # Defaults:
+        # name: [tag name]
+        # tag_name: github.ref
+        body: "## Release Notes\nTODO: Create great release notes!"
+        draft: true
+        files: lrs-admin-ui.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,23 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
 
-    - name: Setup Java
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'temurin'
-        java-version: '11'
-
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-
-    - name: Setup Clojure
-      uses: DeLaGuardo/setup-clojure@3.5
-      with:
-        cli: 1.10.3.943
+    - name: Setup CI Environment
+      uses: yetanalytics/actions/setup-env@v0
 
     - name: Build Bundle
       run: make bundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,12 @@ jobs:
         name: lrs-admin-ui-artifact-${{ github.sha }}
         path: target/bundle/**
 
+    - name: Compress Bundle
+      if: ${{ startsWith(github.ref, 'refs/tags') }}
+      run: | # Need to cd so that the zip file doesn't contain the parent dirs
+        cd target/bundle
+        zip -r ../../lrs-admin-ui.zip ./
+
     - name: Craft Draft Release (Tag Pushes)
       if: ${{ startsWith(github.ref, 'refs/tags') }}
       uses: softprops/action-gh-release@v1
@@ -49,4 +55,4 @@ jobs:
         # tag_name: github.ref
         body: "## Release Notes\nTODO: Create great release notes!"
         draft: true
-        files: target/bundle/**
+        files: lrs-admin-ui.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,17 +33,12 @@ jobs:
     - name: Build Bundle
       run: make bundle
 
-    - name: Compress Bundle
-      run: | # Need to cd so that the zip file doesn't contain the parent dirs
-        cd target/bundle
-        zip -r ../../lrs-admin-ui.zip ./
-
     - name: Archive Bundle (Branch Pushes)
       if: ${{ startsWith(github.ref, 'refs/heads') }}
       uses: actions/upload-artifact@v2
       with:
         name: lrs-admin-ui-artifact-${{ github.sha }}
-        path: lrs-admin-ui.zip
+        path: target/bundle/**
 
     - name: Craft Draft Release (Tag Pushes)
       if: ${{ startsWith(github.ref, 'refs/tags') }}
@@ -54,4 +49,4 @@ jobs:
         # tag_name: github.ref
         body: "## Release Notes\nTODO: Create great release notes!"
         draft: true
-        files: lrs-admin-ui.zip
+        files: target/bundle/**

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ clean:
 	rm -rf target *.log node_modules resources/public/css/style.css resources/public/css/style.css.map
 
 node_modules:
-	npm install
+	npm audit && npm install
 
 dev: 	node_modules
 	clojure -A:fig:build


### PR DESCRIPTION
Sets up build-only github actions (CD) for branch heads, producing artifacts, and for `vX.X.X` tags, producing draft releases.

Additionally adds an audit that will fail out `make node_modules` if vulnerabilities are found, so we can't push even a draft release with known vulnerabilities (at build time at least).

For releases, build artifact is available at `https://github.com/yetanalytics/lrs-admin-ui/releases/download/vX.X.X/lrs-admin-ui.zip`