### PR TITLE
Correct destructuring for server host

### DIFF
--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -141,7 +141,7 @@
 (re-frame/reg-event-fx
  :session/get-me
  global-interceptors
- (fn [{{:keys [server-host] :as db} :db} _]
+ (fn [{{server-host ::db/server-host :as db} :db} _]
    (when (not (get db ::db/oidc-auth))
      {:http-xhrio {:method          :get
                    :uri             (httpfn/serv-uri


### PR DESCRIPTION
Get-me handler was not running because the host was incorrectly derived from app state. This PR fixes that.