### PR TITLE
delete actor ui

### DIFF
--- a/resources/sass/global.scss
+++ b/resources/sass/global.scss
@@ -7,6 +7,13 @@ body {
 }
 
 /**************************************************
+# Section
+**************************************************/
+.section-pad {
+    margin-top: 0.5rem;
+}
+
+/**************************************************
 # a tag
 **************************************************/
 
@@ -90,6 +97,10 @@ a {
 
 .font-rama-semi-bold {
   font-family: RamaGothicESemiBold;
+}
+
+.font-monospace {
+    font-family: monospace;
 }
 
 .font-22 {
@@ -345,6 +356,7 @@ a {
 /**************************************************
 # Input
 **************************************************/
+
 .form-group-input {
   padding: 12.5px;
   font-size: 20px;
@@ -842,7 +854,7 @@ span.close-alert img {
 }
 
 /**************************************************
-# Accordions: Credentails Management
+# Accordions: Credentials Management
 **************************************************/
 .accordion {
   list-style-type: none;

--- a/src/com/yetanalytics/lrs_admin_ui/db.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/db.cljs
@@ -84,6 +84,7 @@
 (s/def ::notifications (s/every ::notification))
 
 (s/def ::enable-statement-html boolean?)
+(s/def ::enable-admin-delete-actor boolean?)
 
 (s/def ::oidc-auth boolean?)
 (s/def ::oidc-enable-local-admin boolean?)
@@ -151,6 +152,7 @@
                           ::xapi-prefix
                           ::notifications
                           ::enable-statement-html
+                          ::enable-admin-delete-actor
                           ::oidc-auth
                           ::oidc-enable-local-admin
                           ::enable-admin-status

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -624,19 +624,16 @@
            :format          (ajax/json-request-format)
            :response-format (ajax/json-response-format {:keywords? false})
            :on-success      [:delete-actor/delete-success actor-ifi]
-           :on-failure      [:delete-actor/server-error (str "tried to delete" actor-ifi)]
+           :on-failure      [:delete-actor/server-error (str "tried to delete " actor-ifi)]
            :interceptors    [httpfn/add-jwt-interceptor]}]]}))
 
 (re-frame/reg-event-fx
  :delete-actor/delete-success
  (fn [_ [_ actor-ifi]]
    {:fx [[:dispatch [:notification/notify true (str "Successfully deleted " actor-ifi)]]]}))
-(def holder (atom nil))
 (re-frame/reg-event-fx
  :delete-actor/server-error
  (fn [_ [_ msg err]]
-   (reset! holder err)
-   (println msg)
    {:fx [[:dispatch [:server-error err]]]}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -624,7 +624,7 @@
            :format          (ajax/json-request-format)
            :response-format (ajax/json-response-format {:keywords? false})
            :on-success      [:delete-actor/delete-success actor-ifi]
-           :on-failure      [:delete-actor/server-error (str "tried to delete " actor-ifi)]
+           :on-failure      [:delete-actor/server-error actor-ifi]
            :interceptors    [httpfn/add-jwt-interceptor]}]]}))
 
 (re-frame/reg-event-fx
@@ -633,8 +633,11 @@
    {:fx [[:dispatch [:notification/notify true (str "Successfully deleted " actor-ifi)]]]}))
 (re-frame/reg-event-fx
  :delete-actor/server-error
- (fn [_ [_ msg err]]
-   {:fx [[:dispatch [:server-error err]]]}))
+ (fn [_ [_ actor-ifi _err]]
+   {:fx [[:dispatch
+          [:server-error {:response
+                          {"error"
+                           (str "Error when attempting to delete actor " actor-ifi)}}]]]}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; OIDC Support

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -213,10 +213,13 @@
  :server-error
  (fn [_ [_ {:keys [response status]}]]
    ;;extract the error and present it in a notification. If 401 or 0, log out.
-   (let [message (if (= status 0)
-                   "Could not connect to LRS!"
-                   (or (response "error")
-                       "An unexpected error has occured!"))]
+   (let [err (response "error")
+         message (cond (= status 0)
+                       "Could not connect to LRS!"
+                       (and err (< (count err) 100))
+                       (str "Error from server: " err)
+                       true
+                       "An unexpected error has occured!")]
      {:fx (cond-> [[:dispatch [:notification/notify true message]]]
             (some #(= status %) [0 401])
             (merge [:dispatch [:session/set-token nil]]))})))

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -40,6 +40,7 @@
                        :credential nil}
          ::db/server-host (or server-host "")
          ::db/xapi-prefix "/xapi"
+         ::db/enable-admin-delete-actor false
          ::db/enable-statement-html true
          ::db/notifications []
          ::db/oidc-auth false

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -218,7 +218,7 @@
                        "Could not connect to LRS!"
                        (and err (< (count err) 100))
                        (str "Error from server: " err)
-                       true
+                       :else
                        "An unexpected error has occured!")]
      {:fx (cond-> [[:dispatch [:notification/notify true message]]]
             (some #(= status %) [0 401])

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -630,14 +630,12 @@
 (re-frame/reg-event-fx
  :delete-actor/delete-success
  (fn [_ [_ actor-ifi]]
-   {:fx [[:dispatch [:notification/notify true (str "Successfully deleted " actor-ifi)]]]}))
+   {:fx [[:dispatch [:notification/notify false (str "Successfully deleted " actor-ifi)]]
+         [:dispatch [:browser/load-xapi]]]}))
 (re-frame/reg-event-fx
  :delete-actor/server-error
  (fn [_ [_ actor-ifi _err]]
-   {:fx [[:dispatch
-          [:server-error {:response
-                          {"error"
-                           (str "Error when attempting to delete actor " actor-ifi)}}]]]}))
+   {:fx [[:dispatch  [:notification/notify true  (str "Error when attempting to delete actor " actor-ifi)]]]}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; OIDC Support

--- a/src/com/yetanalytics/lrs_admin_ui/subs.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/subs.cljs
@@ -55,7 +55,6 @@
  (fn [db _]
    (::db/notifications db)))
 
-
 (reg-sub
  :db/get-login
  (fn [db _]
@@ -326,3 +325,9 @@
  :<- [:status/loading-map]
  (fn [loading-map [_ loading-k]]
    (true? (get loading-map loading-k))))
+
+;; Delete Actor
+(reg-sub
+ :delete-actor/enabled?
+ (fn [db _]
+   (::db/enable-admin-delete-actor db false)))

--- a/src/com/yetanalytics/lrs_admin_ui/views/data_management.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/data_management.cljs
@@ -1,8 +1,8 @@
-(ns com.yetanalytics.lrs-admin-ui.views.special-actions
+(ns com.yetanalytics.lrs-admin-ui.views.data-management
   (:require [com.yetanalytics.lrs-admin-ui.views.delete-actor :refer [delete-actor]]))
 
-(defn special-actions []
+(defn data-management []
       [:div {:class "left-content-wrapper"}
        [:h2 {:class "content-title"}
-        "Special Actions"]
+        "Data Management"]
        [delete-actor]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/delete_actor.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/delete_actor.cljs
@@ -7,7 +7,7 @@
   (case type
     "account" (str "account::" (:name inp) "@" (:home-page inp))
     "mbox" (str "mbox::" inp)
-    "mbox-sha" (str "mbox_sha1sum::" inp)
+    "mbox_sha1sum" (str "mbox_sha1sum::" inp)
     "openid" (str "openid::" inp)))
 
 (defn labeled-input [label ratm]

--- a/src/com/yetanalytics/lrs_admin_ui/views/delete_actor.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/delete_actor.cljs
@@ -33,8 +33,8 @@
        
        (case @ifi-type "account"
              [:<>
-              [labeled-input "homePage" (r/cursor input [:home-page])]
-              [labeled-input "name" (r/cursor input [:name])]]
+              [labeled-input "name" (r/cursor input [:name])]
+              [labeled-input "homePage" (r/cursor input [:home-page])]]
              [labeled-input (name @ifi-type) input])
        [:div.section-pad [:input {:type "button",
                     :class "btn-blue-bold",

--- a/src/com/yetanalytics/lrs_admin_ui/views/delete_actor.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/delete_actor.cljs
@@ -1,0 +1,42 @@
+(ns com.yetanalytics.lrs-admin-ui.views.delete-actor
+  (:require [re-frame.core :refer [dispatch-sync]]
+            [com.yetanalytics.lrs-admin-ui.functions :as fns]
+            [reagent.core :as r]))
+
+(defn inp->ifi [type inp]
+  (case type
+    "account" (str "account::" (:name inp) "@" (:home-page inp))
+    "mbox" (str "mbox::" inp)
+    "mbox-sha" (str "mbox_sha1sum::" inp)
+    "openid" (str "openid::" inp)))
+
+(defn labeled-input [label ratm]
+  [:div.section-pad.labeled-input
+   [:div [:span.font-monospace label] ":"]
+   [:input.round {:type "text"
+            :value @ratm
+            :on-change #(reset! ratm (fns/ps-event-val %))}]])
+
+(defn delete-actor []
+  (let [ifi-types ["mbox" "mbox_sha1sum" "openid" "account"]
+        ifi-type (r/atom (first ifi-types))
+        input (r/atom nil)]
+    (fn []
+      [:div 
+       [:h4 {:class "content-title"}
+        "Delete Actor"]
+       [:div.section-pad (into [:select {:on-change #(do
+                                         (reset! input nil)
+                                         (reset! ifi-type (fns/ps-event-val %)))}]
+                 (for [k ifi-types]
+                   [:option {:value k :key k} k]))]
+       
+       (case @ifi-type "account"
+             [:<>
+              [labeled-input "homePage" (r/cursor input [:home-page])]
+              [labeled-input "name" (r/cursor input [:name])]]
+             [labeled-input (name @ifi-type) input])
+       [:div.section-pad [:input {:type "button",
+                    :class "btn-blue-bold",
+                    :on-click  #(dispatch-sync [:delete-actor/delete-actor (inp->ifi @ifi-type @input)])
+                    :value "DELETE"}]]])))

--- a/src/com/yetanalytics/lrs_admin_ui/views/main.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/main.cljs
@@ -6,7 +6,8 @@
    [com.yetanalytics.lrs-admin-ui.views.menu :refer [menu]]
    [com.yetanalytics.lrs-admin-ui.views.accounts :refer [accounts]]
    [com.yetanalytics.lrs-admin-ui.views.status :refer [status]]
-   [com.yetanalytics.lrs-admin-ui.views.update-password :refer [update-password]]))
+   [com.yetanalytics.lrs-admin-ui.views.update-password :refer [update-password]]
+   [com.yetanalytics.lrs-admin-ui.views.special-actions :refer [special-actions]]))
 
 (defn main []
   [:main {:class "lrs-main"}
@@ -19,5 +20,6 @@
        :browser [browser]
        :accounts [accounts]
        :status [status]
-       :update-password [update-password])]
-    [:div {:class "content-right-wrapper"} ]]])
+       :update-password [update-password]
+       :special-actions [special-actions])]
+    [:div {:class "content-right-wrapper"}]]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/main.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/main.cljs
@@ -7,7 +7,7 @@
    [com.yetanalytics.lrs-admin-ui.views.accounts :refer [accounts]]
    [com.yetanalytics.lrs-admin-ui.views.status :refer [status]]
    [com.yetanalytics.lrs-admin-ui.views.update-password :refer [update-password]]
-   [com.yetanalytics.lrs-admin-ui.views.special-actions :refer [special-actions]]))
+   [com.yetanalytics.lrs-admin-ui.views.data-management :refer [data-management]]))
 
 (defn main []
   [:main {:class "lrs-main"}
@@ -21,5 +21,5 @@
        :accounts [accounts]
        :status [status]
        :update-password [update-password]
-       :special-actions [special-actions])]
+       :data-management [data-management])]
     [:div {:class "content-right-wrapper"}]]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/menu.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/menu.cljs
@@ -19,4 +19,6 @@
     (when @(subscribe [:db/get-stmt-html-enabled])
       [menu-item {:name "Statement Browser" :page :browser}])
     (when @(subscribe [:status/enabled?])
-      [menu-item {:name "LRS Monitor" :page :status}])]])
+      [menu-item {:name "LRS Monitor" :page :status}])
+    (when (some identity [@(subscribe [:delete-actor/enabled?])])
+      [menu-item {:name "Special Actions" :page :special-actions}])]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/menu.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/menu.cljs
@@ -21,4 +21,4 @@
     (when @(subscribe [:status/enabled?])
       [menu-item {:name "LRS Monitor" :page :status}])
     (when (some identity [@(subscribe [:delete-actor/enabled?])])
-      [menu-item {:name "Special Actions" :page :special-actions}])]])
+      [menu-item {:name "Data Management" :page :data-management}])]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/special_actions.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/special_actions.cljs
@@ -1,0 +1,8 @@
+(ns com.yetanalytics.lrs-admin-ui.views.special-actions
+  (:require [com.yetanalytics.lrs-admin-ui.views.delete-actor :refer [delete-actor]]))
+
+(defn special-actions []
+      [:div {:class "left-content-wrapper"}
+       [:h2 {:class "content-title"}
+        "Special Actions"]
+       [delete-actor]])


### PR DESCRIPTION
walkthrough of new actor delete ui:
I've added (through repl) this statement:
![image](https://github.com/yetanalytics/lrs-admin-ui/assets/334165/e7736f7d-ab3c-489f-b37f-7015bea61ce1)

because `enable-admin-delete-actor` is true in `webserver.edn`, "Special Actions" appears:
![image](https://github.com/yetanalytics/lrs-admin-ui/assets/334165/df81f956-e939-4a0b-8fe9-b7257ab8eb82)

Here is the "Special Actions" UI:
![image](https://github.com/yetanalytics/lrs-admin-ui/assets/334165/85eea570-2461-48e1-a92a-ff93c0fdecfa)

Couldn't get a screenshot of the select while open, but options are `mbox`, `mbox_sha1sum`, `openid`, and `account`.  This may seem a little sparse and technical, but I figured I'd minimize confusion by using the exact terms in the [spec](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#actor).  To suggest this, I used monospace font for the input labels.

With `account` selected:
![image](https://github.com/yetanalytics/lrs-admin-ui/assets/334165/d7deda43-bc99-4393-a16b-2ccb6c72f9c4)

As our statement's `actor` property was defined by `mbox`, we select and paste...
![image](https://github.com/yetanalytics/lrs-admin-ui/assets/334165/316342e6-6aab-45d9-b509-9c637499341e)

(Here there was a notification: "Successfully deleted [ifi]", but it disappeared before I could screenshot it---see `handlers.cljs` for text)

If we go back to the Statement Browser and look...it is still there
![image](https://github.com/yetanalytics/lrs-admin-ui/assets/334165/7a232932-57d5-42f9-ae2e-10281005e00a).  Which raises the question: should the backend be updating the frontend?

But if we look at the repl, we can confirm it's gone:

![image](https://github.com/yetanalytics/lrs-admin-ui/assets/334165/c69186e2-202c-4f6e-bfda-8e3fa7765896)



If we put nonsense in...
![image](https://github.com/yetanalytics/lrs-admin-ui/assets/334165/a62ec8be-6774-4108-b00d-252cf192033d)

we get a notification of "Error when attempting to delete actor [actor-ifi]"
