### PR TITLE
csrf-proof lrsql frontend

### DIFF
--- a/resources/sass/login.scss
+++ b/resources/sass/login.scss
@@ -114,11 +114,11 @@
   margin-top: 12px;
 }
 
-form#login-form {
+div#login-form {
   @extend .text-white, .font-condensed;
 }
 
-form#login-form div.form-group:not(:first-child) {
+div#login-form div.form-group:not(:first-child) {
   @extend .mb-0;
 }
 

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -233,7 +233,7 @@
  :server-error
  (fn [_ [_ {:keys [response status]}]]
    ;;extract the error and present it in a notification. If 401 or 0, log out.
-   (let [err (response "error")
+   (let [err (get response "error")
          message (cond (= status 0)
                        "Could not connect to LRS!"
                        (and err (< (count err) 100))

--- a/src/com/yetanalytics/lrs_admin_ui/views/login.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/login.cljs
@@ -14,7 +14,7 @@
         [:img {:src "images/logo.png", :alt "LRS Logo"}]]]
       [:h1 "Login"]
       [:div {:class "form-wrapper"}
-       [:form {:id "login-form"}
+       [:div {:id "login-form"}
         (when show-local-login?
           [:<>
            [:div {:class "form-group"}


### PR DESCRIPTION
 - replaces all `form` elements  with `div`
 - all non-GET frontend requests now attach an "x-csrf-dummy" (with value `null`) header that will be required by a future version of lrsql
 - QoL: frontend handles errors better