### PR TITLE
gracefully handle server errors w/o messages

### DIFF
--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -236,7 +236,9 @@
  :server-error
  (fn [_ [_ {:keys [response status]}]]
    ;;extract the error and present it in a notification. If 401 or 0, log out.
-   (let [err (response "error")
+   (let [err (get response "error"
+                  ;; If no error is provided, pass status
+                  (format "Unknown Error, status: %s" status))
          message (cond (= status 0)
                        "Could not connect to LRS!"
                        (and err (< (count err) 100))


### PR DESCRIPTION
[SQL-232] When a non-successful server response comes in with out an error, our code will NPE. This change supplies a default message carrying the status of the failed request.

[SQL-232]: https://yet.atlassian.net/browse/SQL-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ