### PR TITLE
SQL-250 - keep data browser regardless of HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "lrs-admin-ui",
       "dependencies": {
         "bootstrap": "^4.5.3",
         "codemirror": "5.65.0",
@@ -601,12 +602,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1133,9 +1134,9 @@
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3361,12 +3362,12 @@
       "requires": {}
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browser-resolve": {
@@ -3781,9 +3782,9 @@
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"

--- a/src/com/yetanalytics/lrs_admin_ui/db.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/db.cljs
@@ -95,7 +95,6 @@
 
 (s/def ::notifications (s/every ::notification))
 
-(s/def ::enable-statement-html boolean?)
 (s/def ::enable-admin-delete-actor boolean?)
 
 (s/def ::stmt-get-max int?)
@@ -198,7 +197,6 @@
                           ::language
                           ::pref-lang
                           ::notifications
-                          ::enable-statement-html
                           ::enable-admin-delete-actor
                           ::stmt-get-max
                           ::oidc-auth

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -53,7 +53,6 @@
          ::db/pref-lang :en-US
          ::db/stmt-get-max 10
          ::db/enable-admin-delete-actor false
-         ::db/enable-statement-html true
          ::db/notifications []
          ::db/oidc-auth false
          ::db/oidc-enable-local-admin false
@@ -86,7 +85,6 @@
  global-interceptors
  (fn [{:keys [db]} [_ {:keys             [url-prefix
                                           proxy-path
-                                          enable-stmt-html
                                           enable-admin-status
                                           enable-reactions
                                           no-val?
@@ -100,7 +98,6 @@
    {:db (cond-> (assoc db
                        ::db/xapi-prefix url-prefix
                        ::db/proxy-path proxy-path
-                       ::db/enable-statement-html enable-stmt-html
                        ::db/oidc-enable-local-admin (or ?oidc-local-admin false)
                        ::db/enable-admin-status enable-admin-status
                        ::db/enable-reactions enable-reactions

--- a/src/com/yetanalytics/lrs_admin_ui/subs.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/subs.cljs
@@ -198,11 +198,6 @@
  (fn [{:keys [back-stack]} _]
    back-stack))
 
-(reg-sub
- :db/get-stmt-html-enabled
- (fn [db _]
-   (::db/enable-statement-html db)))
-
 ;; OIDC State
 (reg-sub
  :oidc/login-available?

--- a/src/com/yetanalytics/lrs_admin_ui/views/menu.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/menu.cljs
@@ -16,8 +16,7 @@
     [menu-item {:name @(subscribe [:lang/get :header.nav.credentials]) :page :credentials}]
     (when @(subscribe [:oidc/show-account-nav?])
       [menu-item {:name @(subscribe [:lang/get :header.nav.accounts]) :page :accounts}])
-    (when @(subscribe [:db/get-stmt-html-enabled])
-      [menu-item {:name @(subscribe [:lang/get :header.nav.browser]) :page :browser}])
+    [menu-item {:name @(subscribe [:lang/get :header.nav.browser]) :page :browser}]
     (when @(subscribe [:status/enabled?])
       [menu-item {:name @(subscribe [:lang/get :header.nav.monitor]) :page :status}])
     (when (some identity [@(subscribe [:delete-actor/enabled?])])


### PR DESCRIPTION
Legacy data browser used HTML content negotiation, but new one does not. This just keeps data browser enabled regardless of that setting.