### PR TITLE
Store proxy-path because of refresh

### DIFF
--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -48,7 +48,7 @@
                        :back-stack []}
          ::db/server-host (or server-host "")
          ::db/xapi-prefix "/xapi"
-         ::db/proxy-path  nil
+         ::db/proxy-path (stor/get-item "proxy-path")
          ::db/language lang/language
          ::db/pref-lang :en-US
          ::db/stmt-get-max 10
@@ -112,7 +112,8 @@
           (assoc ::db/no-val-logout-url no-val-logout-url))
     :fx (cond-> []
           ?oidc (conj [:dispatch [:oidc/init ?oidc]])
-          no-val? (conj [:dispatch [:session/proxy-token-init]]))}))
+          no-val? (conj [:dispatch [:session/proxy-token-init]]))
+    :session/store ["proxy-path" proxy-path]}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Login / Auth


### PR DESCRIPTION
This one is not obvious. Basically the issue is that if you do NOT refresh the page when using proxy mode it all works fine because it has the proxy-path in reframe db from /env, and tacks it onto the calls. When you DO refresh, /env and /creds get triggered. Rather than setup a complicated conditional dependency between them, the simple fix is just to store the proxy-path in application storage same as the JWT. 

If you _have_ a JWT it will attempt a creds call and skip auth, and then it will be informed of the path for that call. 

If you don't have a JWT it will just do what it normally does and go to login and grab /env and store the path for later.