### PR TITLE
Actions update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup CI Environment
-      uses: yetanalytics/action-setup-env@v1
+      uses: yetanalytics/action-setup-env@v2
 
     - name: Build Bundle
       run: make bundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Craft Draft Release (Tag Pushes)
       if: ${{ startsWith(github.ref, 'refs/tags') }}
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         # Defaults:
         # name: [tag name]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       uses: yetanalytics/action-setup-env@v2
 
     - name: Cache Deps
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup CI Environment
-      uses: yetanalytics/action-setup-env@v1
+      uses: yetanalytics/action-setup-env@v2
 
     - name: Cache Deps
       uses: actions/cache@v3

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -16,7 +16,7 @@ jobs:
         uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup CI Environment
-        uses: yetanalytics/action-setup-env@v1
+        uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
         uses: actions/cache@v3


### PR DESCRIPTION
Update additional actions:
- yetanalytics/action-setup-env to v2
- softprops/actions-gh-release to v2
- actions/cache to v4

Do not update the following action:
- advanced-security/maven-dependency-submission-action due to additional breaking changes beyond Node updates