### PR TITLE
[SQL-258][SQL-259] Reaction UI bugfixes and enhancements

### DIFF
--- a/resources/sass/reactions.scss
+++ b/resources/sass/reactions.scss
@@ -5,15 +5,15 @@
 $dl-nesting-depth: 1em;
 $condition-padding: 1em;
 
-dl.reaction-view > dd {
+div.reaction-view > span {
   padding-left: $dl-nesting-depth;
 }
 
-dl.reaction-ruleset > dd {
+div.reaction-ruleset > label {
   padding-left: $dl-nesting-depth;
 }
 
-dl.reaction-ruleset > dt {
+div.reaction-ruleset > div {
   padding-bottom: 8px;
 }
 

--- a/src/com/yetanalytics/lrs_admin_ui/functions/reaction.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/functions/reaction.cljs
@@ -119,3 +119,29 @@
       (select-keys [:id :title :active :ruleset])
       (rename-keys {:id :reactionId})
       (update-in [:ruleset :conditions] mapify-conditions)))
+
+;; Path selection dropdown ordering
+
+(def selection-order
+  {"id"          0
+   "name"        1
+   "display"     2
+   "definition"  3
+   "description" 4})
+
+(defn order-select-entries
+  "Order path segment select entries by placing ID and lang map properties at
+   the top, then alphabetically for the rest."
+  [selects]
+  (sort-by :label
+           (fn [x y]
+             (let [x-order (get selection-order x)
+                   y-order (get selection-order y)]
+               (cond
+                 (and x-order
+                      y-order)
+                 (< x-order y-order)
+                 x-order true
+                 y-order false
+                 :else   (< x y))))
+           selects))

--- a/src/com/yetanalytics/lrs_admin_ui/functions/reaction.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/functions/reaction.cljs
@@ -1,7 +1,9 @@
 (ns com.yetanalytics.lrs-admin-ui.functions.reaction
-  (:require [goog.string      :refer [format]]
-            [xapi-schema.core :as xs]
-            [goog.string.format]))
+  (:require [clojure.set  :refer [rename-keys]]
+            [clojure.walk :as w]
+            [goog.string  :refer [format]]
+            [goog.string.format]
+            [xapi-schema.core :as xs]))
 
 (defn path->string
   "Given a vector of keys and/or indices, return a JSONPath string suitable for
@@ -38,52 +40,6 @@
     (nil? val)
     "null"))
 
-(defn index-conditions
-  "Provide sort-indices for reaction conditions editing. Base order on prior
-  indices if available."
-  [reaction]
-  (update-in
-   reaction
-   [:ruleset :conditions]
-   (fn [conditions]
-     (reduce
-      (fn [m
-           [idx
-            [condition-key
-             condition-val]]]
-        (assoc
-         m
-         condition-key
-         (assoc condition-val :sort-idx idx)))
-      {}
-      (map-indexed
-       vector
-       (sort-by
-        (comp :sort-idx val)
-        conditions))))))
-
-(defn strip-condition-indices
-  "Remove all indices from conditions."
-  [reaction]
-  (update-in
-   reaction
-   [:ruleset :conditions]
-   (fn [conditions]
-     (reduce-kv
-      (fn [m k v]
-        (assoc m k (dissoc v :sort-idx)))
-      {}
-      conditions))))
-
-(defn fix-ruleset-in-path
-  "Clojure spec adds an array idx to the :in path on failures of map-of specs.
-  This function takes a reaction ruleset condition path and adds the idx,
-  making the path usable for finding things."
-  [[seg0 seg1 seg2 & rest-seg :as path]]
-  (if (and (= [:ruleset :conditions] [seg0 seg1]) seg2)
-    (into [seg0 seg1 seg2 1] rest-seg)
-    path))
-
 (defn validate-template-xapi
   "Take raw JSON str of an xAPI Statement and issue a vec of error maps for 
    any schema violations. Returns `nil` if `raw-json` is valid."
@@ -109,3 +65,57 @@
               {:message (format "xAPI Validation Error in: %s" path)}))))
        []
        (-> e ex-data :error :cljs.spec.alpha/problems)))))
+
+;; Conversion functions
+
+(defn- vectorize-conditions
+  [conditions]
+  (reduce-kv
+   (fn [acc cond-name condition]
+     (conj acc (assoc condition :name (name cond-name))))
+   []
+   conditions))
+
+(defn- mapify-conditions
+  [conditions]
+  (reduce
+   (fn [m {cond-name :name :as condition}]
+     (assoc m (keyword cond-name) (dissoc condition :name)))
+   {}
+   conditions))
+
+(defn db->focus-form
+  "Convert `reaction` from how it is stored in the LRS backend into its
+   UI view form."
+  [reaction]
+  (-> reaction
+      (update-in [:ruleset :template] w/stringify-keys)))
+
+(defn focus->edit-form
+  "Convert `reaction` from its UI view form to its edit form."
+  [reaction]
+  (-> reaction
+      (update-in [:ruleset :conditions] vectorize-conditions)))
+
+(defn focus->download-form
+  "Convert `reaction` from its UI view form to its download form."
+  [reaction]
+  (-> reaction
+      (select-keys [:title :ruleset :active])))
+
+(defn upload->edit-form
+  "Convert `reaction` from an upload form to its edit form."
+  [reaction]
+  (-> reaction
+      (select-keys [:title :ruleset :active])
+      (update-in [:ruleset :template] w/stringify-keys)
+      (update-in [:ruleset :conditions] vectorize-conditions)))
+
+(defn edit->db-form
+  "Convert `reaction` from its edit form to how it is stored in the
+   LRS backend."
+  [reaction]
+  (-> reaction
+      (select-keys [:id :title :active :ruleset])
+      (rename-keys {:id :reactionId})
+      (update-in [:ruleset :conditions] mapify-conditions)))

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -1525,14 +1525,18 @@
  :reaction/add-condition
  global-interceptors
  (fn [db [_ ?condition-key]]
-   (let [k (or ?condition-key (keyword (format "condition_%s"
+   (let [cond-count (count (get-in db [::db/editing-reaction
+                                       :ruleset
+                                       :conditions]))
+         k (or ?condition-key (keyword (format "condition_%s"
                                                (fns/rand-alpha-str 8))))]
      (-> db
          (update-in
           [::db/editing-reaction :ruleset :conditions]
-          assoc k {:path [""]
-                   :op   "eq"
-                   :val  ""})
+          assoc k {:path     [""]
+                   :op       "eq"
+                   :val      ""
+                   :sort-idx cond-count})
          (update
           ::db/editing-reaction
           rfns/index-conditions)))))

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -1331,12 +1331,12 @@
                               path-before)
          parent-path (butlast full-path)]
      (-> db
-       (update-in full-path
-                  conj
-                  (if (= '[idx] next-keys) 0 ""))
-       (update-in
-        parent-path
-        ensure-val-type)))))
+         (update-in full-path
+                    conj
+                    (if (= '[idx] next-keys) 0 ""))
+         (update-in
+          parent-path
+          ensure-val-type)))))
 
 (re-frame/reg-event-db
  :reaction/del-path-segment
@@ -1362,14 +1362,17 @@
          path-before         (get-in db full-path)
          path-after          (conj (vec (butlast path-before))
                                    new-seg-val)
-         {:keys [complete?]} (rpath/analyze-path path-after)
+         {:keys [leaf-type
+                 complete?]} (rpath/analyze-path path-after)
          parent-path         (butlast full-path)]
      (cond-> {:db (-> db
                       (assoc-in full-path path-after)
                       (update-in
                        parent-path
                        ensure-val-type))}
-       (and (not complete?) open-next?)
+       (and (not complete?)
+            (not= 'json leaf-type) ; not extension
+            open-next?)
        (assoc :fx [[:dispatch [:reaction/add-path-segment path-path]]])))))
 
 (re-frame/reg-event-db

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -1333,7 +1333,7 @@
     (let [{:keys [leaf-type]} (rpath/analyze-path path)]
       (if leaf-type
         (let [vtype (val-type val)]
-          (assoc c :val (if (= leaf-type vtype)
+          (assoc c :val (if (= (str leaf-type) vtype)
                           val
                           (init-type leaf-type))))
         c))))

--- a/src/com/yetanalytics/lrs_admin_ui/language.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/language.cljs
@@ -147,6 +147,8 @@
    :reactions.errors.like-string {:en-US "The 'like' op only supports string values."}
    :reactions.errors.invalid {:en-US "Reaction is invalid see below."}
    :reactions.errors.one-condition {:en-US "Ruleset must specify at least one condition."}
+   :reactions.errors.dupe-condition-names {:en-US "Ruleset cannot have duplicate condition names."}
+   :reactions.errors.invalid-condition-name {:en-US "Condition name must not include spaces or `/` characters, or start with `@` symbols."}
    :reactions.errors.one-clause {:en-US "Condition must have at least one clause."}
 
    ;;Account Management

--- a/src/com/yetanalytics/lrs_admin_ui/language.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/language.cljs
@@ -162,7 +162,7 @@
    :account-mgmt.update-password.password.new {:en-US "New Password"}
    :account-mgmt.update-password.password.copy {:en-US "Copy"}
    :account-mgmt.update-password.password.generate {:en-US "Generate Password"}
-   
+
 
    ;;Tooltips
    :tooltip.reactions.title {:en-US "Reactions is a new functionality for SQL LRS that allows for the generation of custom xAPI statements triggered by other statements posted to the LRS. An administrator can configure rulesets that match one or more incoming xAPI statement(s), based on conditions, and generate a custom statement which is added to the LRS. -- This can be used for statement transformation (e.g. integration with systems expecting a certain statement format the provider does not make) and statement aggregation (e.g. generate summary statements or assertions about groups of statements)."}
@@ -190,4 +190,8 @@
    :notification.credentials.secret-copied {:en-US "Copied Secret Key!"}
    :notification.accounts.password-copied {:en-US "Copied New Password!"}
    :notification.reactions.copied-template-var {:en-US "Copied Template Variable to Clipboard!"}
-   :notification.account-mgmt.copied-password {:en-US "Copied New Password!"}})
+   :notification.account-mgmt.copied-password {:en-US "Copied New Password!"}
+
+   ;;Form Components
+   :form.search-or-add {:en-US "Search or Add"}
+   :form.add {:en-US "Add"}})

--- a/src/com/yetanalytics/lrs_admin_ui/spec/reaction_edit.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/spec/reaction_edit.cljs
@@ -1,7 +1,27 @@
 (ns com.yetanalytics.lrs-admin-ui.spec.reaction-edit
   "Duplicates com.yetanalytics.lrs-reactions.spec, but relaxed for edit"
   (:require [cljs.spec.alpha :as s :include-macros true]
+            [clojure.string :as cstr]
             [com.yetanalytics.lrs-reactions.spec :as rs]))
+
+;; Validation functions
+
+(defn keywordizable-string?
+  "Can `s` be converted into a valid simple keyword?"
+  [s]
+  (and string? ; string needs to be keywordizable into simple strings
+       (not (cstr/starts-with? s "@"))
+       (not (cstr/includes? s " "))
+       (not (cstr/includes? s "/"))))
+
+(defn distinct-name-vector?
+  "Is `v` a vector whose entries' `:name` properties are all distinct?"
+  [v]
+  (and (vector? v)
+       (= (->> v (map :name) count)
+          (->> v (map :name) distinct count))))
+
+;; Basic condition specs for app-db specs
 
 ;; Conditions do not have logic validation
 (s/def ::condition
@@ -19,22 +39,39 @@
 ;; NOT is nilable
 (s/def ::not (s/nilable ::condition))
 
-;; A :sort-idx is added to top-level conditions for ordering
-(s/def ::sort-idx nat-int?)
+;; Condition specs for both app-db and validation
+
+(s/def :condition/name
+  string?)
+
+(s/def :validation/name
+  keywordizable-string?)
 
 (s/def ::top-level-condition
-  (s/or
-   :indexed-condition
-   (s/merge ::condition
-            (s/keys :req-un [::sort-idx]))
-   :empty-condition
-   (s/keys :req-un [::sort-idx])))
+  (s/or :not-empty
+        (s/merge ::condition
+                 (s/keys :req-un [:condition/name]))
+        :empty
+        (s/keys :req-un [:condition/name])))
 
-;; Condition map vals are nilable
+(s/def :validation/top-level-condition
+  (s/or :not-empty
+        (s/merge ::rs/condition
+                 (s/keys :req-un [:validation/name]))
+        :empty
+        (s/and (s/keys :req-un [:validation/name])
+               #(= '(:name) (keys %)))))
+
 (s/def ::conditions
-  (s/map-of simple-keyword?
-            ::top-level-condition
-            :gen-max 3))
+  (s/coll-of ::top-level-condition
+             :kind vector?
+             :gen-max 3))
+
+(s/def :validation/conditions
+  (s/coll-of :validation/top-level-condition
+             :kind distinct-name-vector?
+             :min-count 1
+             :gen-max 3))
 
 ;; :identityPaths is only checked for structure
 (s/def ::identityPaths
@@ -45,6 +82,11 @@
                    ::conditions
                    ::rs/template]))
 
+(s/def :validation/ruleset
+  (s/keys :req-un [::rs/identityPaths
+                   ::rs/template
+                   :validation/conditions]))
+
 ;; Representation
 (s/def ::id string?)
 (s/def ::title string?)
@@ -52,12 +94,20 @@
 (s/def ::created string?)
 (s/def ::modified string?)
 
-
 (s/def ::reaction
   (s/keys :req-un [::title
-                   ::ruleset
-                   ::active]
+                   ::active
+                   ::ruleset]
           :opt-un [::id
                    ::created
                    ::modified
                    ::rs/error]))
+
+;; TODO: Use fully-qualified namespace alias in Clojure 1.11
+(s/def :validation/reaction
+  (s/keys :req-un [::title
+                   ::active
+                   :validation/ruleset]
+          :opt-un [::id
+                   ::created
+                   ::modified]))

--- a/src/com/yetanalytics/lrs_admin_ui/subs.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/subs.cljs
@@ -4,7 +4,7 @@
             [com.yetanalytics.lrs-admin-ui.functions.time :as t]
             [com.yetanalytics.lrs-admin-ui.input :as i]
             [com.yetanalytics.lrs-admin-ui.functions.reaction :as rfns]
-            [com.yetanalytics.lrs-admin-ui.spec.reaction :as rs]
+            [com.yetanalytics.lrs-admin-ui.spec.reaction-edit]
             [clojure.spec.alpha :as s :include-macros true]))
 
 (reg-sub
@@ -419,7 +419,7 @@
    (some
     (fn [{:keys [id] :as reaction}]
       (when (= focus-id id)
-        reaction))
+        (rfns/db->focus-form reaction)))
     reaction-list)))
 
 (reg-sub
@@ -435,19 +435,19 @@
        {:keys [id] :as editing}]]
    (and (some? editing)
         (or (nil? id)
-            (not= (rfns/strip-condition-indices editing)
+            (not= editing
                   (some
                    (fn [{r-id :id
                          :as  reaction}]
                      (when (= r-id id)
-                       reaction))
+                       (rfns/focus->edit-form reaction)))
                    reaction-list))))))
 
 (reg-sub
  :reaction/edit-condition-names
  :<- [:reaction/editing]
  (fn [{{:keys [conditions]} :ruleset} _]
-   (map name (keys conditions))))
+   (map :name conditions)))
 
 (reg-sub
  :reaction/edit-template-json
@@ -484,9 +484,8 @@
  (fn [editing _]
    (when editing
      (some-> (s/explain-data
-              ::rs/new-reaction
-              (rfns/strip-condition-indices
-               editing))
+              :validation/reaction
+              editing)
              :cljs.spec.alpha/problems))))
 
 (reg-sub
@@ -503,7 +502,7 @@
  :reaction/edit-spec-errors-in
  :<- [:reaction/edit-spec-errors-map]
  (fn [emap [_ in-path]]
-   (get emap (rfns/fix-ruleset-in-path in-path))))
+   (get emap in-path)))
 
 ;; Dialog
 

--- a/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
@@ -2,10 +2,12 @@
   (:require [reagent.core :as r]
             [com.yetanalytics.lrs-admin-ui.functions :as fns]
             [com.yetanalytics.lrs-admin-ui.views.form.dropdown
+             :as drop-form
              :refer [make-key-down-fn
                      select-input-top
                      dropdown-items
-                     combo-box-dropdown]]))
+                     combo-box-dropdown
+                     action-select-top]]))
 
 ;; Combo Box Input ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -50,6 +52,8 @@
                             (reset! dropdown-open? false)))]
     (fn []
       (let [opts-coll      (vec (options-fn))
+            curr-label     (or (drop-form/get-label opts-coll @current-value)
+                               (str @current-value))
             on-key-down-fn (make-key-down-fn
                             {:options         opts-coll
                              :dropdown-focus  dropdown-focus
@@ -67,9 +71,8 @@
           [select-input-top
            {:id             id
             :disabled       disabled
-            :options        opts-coll
-            :current-value  current-value
             :dropdown-open? dropdown-open?
+            :label          curr-label
             :placeholder    placeholder}]
           (when (and (not disabled) @dropdown-open?)
             [combo-box-dropdown
@@ -106,16 +109,11 @@
        {:on-blur (fn [_]
                    ;; FIXME: Horrible hack, can't figure out how to stop the clobbering here
                    (js/setTimeout #(swap! state assoc :dropdown-open? false) 200))}
-       [:div.action-dropdown-icon
-        [:a {:href "#"
-             :on-click (fn [e]
-                         (fns/ps-event e)
-                         (swap! state assoc :dropdown-open? true))}
-         (when (and label label-left?)
-           [:span.action-dropdown-label (str label " ")])
-         [:img {:src icon-src}]
-         (when (and label (not label-left?))
-           [:span.action-dropdown-label (str " " label)])]]
+       [action-select-top
+        {:label          label
+         :label-left?    label-left?
+         :icon-src       icon-src
+         :dropdown-open? dropdown-open?}]
        [:div.action-dropdown-list
         {:class (str class (if @dropdown-open? " dropdown-open" ""))}
         [dropdown-items

--- a/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
@@ -5,9 +5,7 @@
              :refer [make-key-down-fn
                      select-input-top
                      dropdown-items
-                     combo-box-dropdown]]
-            [goog.string :refer [format]]
-            [goog.string.format]))
+                     combo-box-dropdown]]))
 
 ;; Combo Box Input ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -25,30 +23,16 @@
    | `disabled`     | Is the combo box disabled? If so, the dropdown can't be opened.
    | `custom-text?` | Is the user allowed to input custom text, and not just the select options?
    | `options-fn`   | A thunk that returns the options list.
-   | `tooltip`      | A keyword or string that corresponds to tooltip info when the user hovers over the info icon.
-   | `required`     | A boolean that will show a required indicator if true.
-   | `err-sub`      | A subscription vector to buffer errors that may include errors corresponding to this component.
-   | `err-match`    | An error location vector for filtering errors from err-sub. It is treated as a prefix and will match any error that begins with it.
-   | `removable?`   | When true, a \"(None)\" option will appear as the first item in the dropdown; clicking it results in passing `nil` to `on-change`.
-   | `remove-text`  | The dropdown label for `nil` when `removable?` is `true`. Default is \"(None)\"."
-  [{:keys [id name on-change on-search value placeholder disabled custom-text?
-           options-fn
-           #_:clj-kondo/ignore tooltip
-           #_:clj-kondo/ignore err-sub
-           #_:clj-kondo/ignore err-match
-           #_:clj-kondo/ignore required
-           removable? remove-text]
-    :or {name        (random-uuid)
-         id          (random-uuid)
+   | `required`     | A boolean that will show a required indicator if true."
+  [{:keys [id on-change on-search value placeholder disabled custom-text?
+           options-fn]
+    :or {id          (random-uuid)
          disabled    false
          value       ""
          placeholder "Please make your selection"
          on-change   identity
          on-search   (constantly nil)
-         options-fn  (constantly [])
-         removable?  false
-         remove-text "(None)"}}
-   & #_:clj-kondo/ignore label]
+         options-fn  (constantly [])}}]
   (let [combo-box-ratom (r/atom {:current-value value
                                  :dropdown {:open? false
                                             :focus 0
@@ -65,9 +49,7 @@
                           (when-not (fns/child-event? e)
                             (reset! dropdown-open? false)))]
     (fn []
-      (let [opts-coll      (cond->> (vec (options-fn))
-                             removable?
-                             (into [{:value nil :label remove-text}]))
+      (let [opts-coll      (vec (options-fn))
             on-key-down-fn (make-key-down-fn
                             {:options         opts-coll
                              :dropdown-focus  dropdown-focus
@@ -75,17 +57,15 @@
                              :value-update-fn value-update-fn
                              :space-select?   false})]
         [:div
-         #_[form-label label id tooltip required err-sub err-match]
          [:div {:id          id
                 :disabled    disabled
                 :tab-index   0
                 :class       "form-custom-select-input"
                 :on-key-down on-key-down-fn
                 :on-blur     on-blur-fn
-                :aria-label  (format "Combo Box Input for %s" name)}
+                :aria-label  "Combo Box Input"}
           [select-input-top
            {:id             id
-            :name           name
             :disabled       disabled
             :options        opts-coll
             :current-value  current-value
@@ -94,7 +74,6 @@
           (when (and (not disabled) @dropdown-open?)
             [combo-box-dropdown
              {:id               id
-              :name             name
               :dropdown-focus   dropdown-focus
               :dropdown-value   dropdown-value
               :value-update-fn  value-update-fn

--- a/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
@@ -2,23 +2,14 @@
   (:require [reagent.core :as r]
             [com.yetanalytics.lrs-admin-ui.functions :as fns]
             [com.yetanalytics.lrs-admin-ui.views.form.dropdown
-             :as form-drop
              :refer [make-key-down-fn
                      select-input-top
-                     dropdown-items]]
+                     dropdown-items
+                     combo-box-dropdown]]
             [goog.string :refer [format]]
             [goog.string.format]))
 
 ;; Combo Box Input ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn combo-box-dropdown
-  "A dropdown specific for combo boxes, including the search bar."
-  [{:keys [id name] :as opts}]
-  [:div {:id    (str id "-dropdown")
-         :name  (str name "-dropdown")
-         :class "form-select-dropdown"}
-   [form-drop/combo-box-search opts]
-   [form-drop/dropdown-items opts]])
 
 (defn combo-box-input
   "A combo box for selecting a single item.
@@ -34,10 +25,19 @@
    | `disabled`     | Is the combo box disabled? If so, the dropdown can't be opened.
    | `custom-text?` | Is the user allowed to input custom text, and not just the select options?
    | `options-fn`   | A thunk that returns the options list.
+   | `tooltip`      | A keyword or string that corresponds to tooltip info when the user hovers over the info icon.
+   | `required`     | A boolean that will show a required indicator if true.
+   | `err-sub`      | A subscription vector to buffer errors that may include errors corresponding to this component.
+   | `err-match`    | An error location vector for filtering errors from err-sub. It is treated as a prefix and will match any error that begins with it.
    | `removable?`   | When true, a \"(None)\" option will appear as the first item in the dropdown; clicking it results in passing `nil` to `on-change`.
    | `remove-text`  | The dropdown label for `nil` when `removable?` is `true`. Default is \"(None)\"."
   [{:keys [id name on-change on-search value placeholder disabled custom-text?
-           options-fn removable? remove-text]
+           options-fn
+           #_:clj-kondo/ignore tooltip
+           #_:clj-kondo/ignore err-sub
+           #_:clj-kondo/ignore err-match
+           #_:clj-kondo/ignore required
+           removable? remove-text]
     :or {name        (random-uuid)
          id          (random-uuid)
          disabled    false
@@ -48,7 +48,7 @@
          options-fn  (constantly [])
          removable?  false
          remove-text "(None)"}}
-   dropdown-panel]
+   & #_:clj-kondo/ignore label]
   (let [combo-box-ratom (r/atom {:current-value value
                                  :dropdown {:open? false
                                             :focus 0
@@ -64,7 +64,7 @@
         on-blur-fn      (fn [e]
                           (when-not (fns/child-event? e)
                             (reset! dropdown-open? false)))]
-    (fn [_]
+    (fn []
       (let [opts-coll      (cond->> (vec (options-fn))
                              removable?
                              (into [{:value nil :label remove-text}]))
@@ -74,31 +74,33 @@
                              :dropdown-open?  dropdown-open?
                              :value-update-fn value-update-fn
                              :space-select?   false})]
-        [:div {:id          id
-               :disabled    disabled
-               :tab-index   0
-               :class       "form-custom-select-input"
-               :on-key-down on-key-down-fn
-               :on-blur     on-blur-fn
-               :aria-label  (format "Combo Box Input for %s" name)}
-         [select-input-top
-          {:id             id
-           :name           name
-           :disabled       disabled
-           :options        opts-coll
-           :current-value  current-value
-           :dropdown-open? dropdown-open?
-           :placeholder    placeholder}]
-         (when (and (not disabled) @dropdown-open?)
-           [dropdown-panel
-            {:id               id
-             :name             name
-             :dropdown-focus   dropdown-focus
-             :dropdown-value   dropdown-value
-             :value-update-fn  value-update-fn
-             :search-update-fn on-search
-             :options          opts-coll
-             :custom-text?     custom-text?}])]))))
+        [:div
+         #_[form-label label id tooltip required err-sub err-match]
+         [:div {:id          id
+                :disabled    disabled
+                :tab-index   0
+                :class       "form-custom-select-input"
+                :on-key-down on-key-down-fn
+                :on-blur     on-blur-fn
+                :aria-label  (format "Combo Box Input for %s" name)}
+          [select-input-top
+           {:id             id
+            :name           name
+            :disabled       disabled
+            :options        opts-coll
+            :current-value  current-value
+            :dropdown-open? dropdown-open?
+            :placeholder    placeholder}]
+          (when (and (not disabled) @dropdown-open?)
+            [combo-box-dropdown
+             {:id               id
+              :name             name
+              :dropdown-focus   dropdown-focus
+              :dropdown-value   dropdown-value
+              :value-update-fn  value-update-fn
+              :search-update-fn on-search
+              :options          opts-coll
+              :custom-text?     custom-text?}])]]))))
 
 ;; Action Dropdown ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
@@ -46,30 +46,30 @@
         dropdown-open?  (r/cursor combo-box-ratom [:dropdown :open?])
         dropdown-focus  (r/cursor combo-box-ratom [:dropdown :focus])
         dropdown-value  (r/cursor combo-box-ratom [:dropdown :value])
-        value-update-fn (fn [value]
+        on-enter        (fn [value]
                           (reset! current-value value)
                           (reset! dropdown-open? false)
                           (on-change @current-value))
-        on-blur-fn      (fn [e]
+        on-blur         (fn [e]
                           (when-not (fns/child-event? e)
                             (reset! dropdown-open? false)))]
     (fn []
       (let [options*       @options-ref
             curr-label     (or (drop-form/get-label options* @current-value)
                                (str @current-value))
-            on-key-down-fn (make-key-down-fn
-                            {:options         options*
-                             :dropdown-focus  dropdown-focus
-                             :dropdown-open?  dropdown-open?
-                             :value-update-fn value-update-fn
-                             :space-select?   false})]
+            on-key-down    (make-key-down-fn
+                            {:options        options*
+                             :dropdown-focus dropdown-focus
+                             :dropdown-open? dropdown-open?
+                             :on-enter       on-enter
+                             :space-select?  false})]
         [:div
          [:div {:id          id
                 :disabled    disabled
                 :tab-index   0
                 :class       "form-custom-select-input"
-                :on-key-down on-key-down-fn
-                :on-blur     on-blur-fn
+                :on-key-down on-key-down
+                :on-blur     on-blur
                 :aria-label  "Combo Box Input"}
           [select-input-top
            {:id             id
@@ -79,14 +79,14 @@
             :placeholder    placeholder}]
           (when (and (not disabled) @dropdown-open?)
             [combo-box-dropdown
-             {:id               id
-              :dropdown-focus   dropdown-focus
-              :dropdown-value   dropdown-value
-              :value-update-fn  value-update-fn
-              :on-search        (fn [search-str]
-                                  (reset! options-ref
-                                          (on-filter options search-str)))
-              :options          options*}])]]))))
+             {:id             id
+              :dropdown-focus dropdown-focus
+              :dropdown-value dropdown-value
+              :on-enter       on-enter
+              :on-search      (fn [search-str]
+                                (reset! options-ref
+                                        (on-filter options search-str)))
+              :options        options*}])]]))))
 
 (defn combo-box-numeric-input
   "A combo box for selecting a single item.
@@ -112,7 +112,7 @@
                                             :value nil}})
         current-value   (r/cursor combo-box-ratom [:current-value])
         dropdown-open?  (r/cursor combo-box-ratom [:dropdown :open?])
-        value-update-fn (fn [value]
+        on-enter        (fn [value]
                           (reset! current-value value)
                           (reset! dropdown-open? false)
                           (on-change @current-value))
@@ -139,10 +139,10 @@
             :placeholder    placeholder}]
           (when (and (not disabled) @dropdown-open?)
             [combo-box-numeric
-             {:id              id
-              :min             min
-              :dropdown-value  current-value
-              :value-update-fn value-update-fn}])]]))))
+             {:id             id
+              :min            min
+              :dropdown-value current-value
+              :on-enter       on-enter}])]]))))
 
 ;; Action Dropdown ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -177,9 +177,8 @@
        [:div.action-dropdown-list
         {:class (str class (if @dropdown-open? " dropdown-open" ""))}
         [dropdown-items
-         {:id id
-          :name id
+         {:id             id
+          :name           id
           :dropdown-focus dropdown-focus
-          :value-update-fn (fn [v]
-                             (select-fn v))
-          :options options}]]])))
+          :on-enter       select-fn
+          :options        options}]]])))

--- a/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
@@ -3,7 +3,8 @@
             [com.yetanalytics.lrs-admin-ui.functions :as fns]
             [com.yetanalytics.lrs-admin-ui.views.form.dropdown
              :as drop-form
-             :refer [make-key-down-fn
+             :refer [make-key-down-fn*
+                     make-key-down-fn
                      select-input-top
                      dropdown-items
                      combo-box-dropdown
@@ -118,18 +119,14 @@
                             (reset! dropdown-open? false)))]
     (fn []
       (let [curr-label     (str @current-value)
-            #_#_on-key-down-fn (make-key-down-fn
-                                {:options         opts-coll
-                                 :dropdown-focus  dropdown-focus
-                                 :dropdown-open?  dropdown-open?
-                                 :value-update-fn value-update-fn
-                                 :space-select?   false})]
+            on-key-down-fn (make-key-down-fn*
+                            {:dropdown-open?  dropdown-open?})]
         [:div
          [:div {:id          id
                 :disabled    disabled
                 :tab-index   0
                 :class       "form-custom-select-input"
-                #_#_:on-key-down on-key-down-fn
+                :on-key-down on-key-down-fn
                 :on-blur     on-blur-fn
                 :aria-label  "Combo Box Input"}
           [select-input-top

--- a/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form.cljs
@@ -7,6 +7,7 @@
                      select-input-top
                      dropdown-items
                      combo-box-dropdown
+                     combo-box-numeric
                      action-select-top]]))
 
 ;; Combo Box Input ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -83,6 +84,66 @@
               :search-update-fn on-search
               :options          opts-coll
               :custom-text?     custom-text?}])]]))))
+
+(defn combo-box-numeric-input
+  "A combo box for selecting a single item.
+
+   | Key | Description
+   | --- | ---
+   | `id`           | The ID of the combo box in the DOM.
+   | `name`         | The name of the combo box.
+   | `min`          | The minimum numeric value the value can be (as a string).
+   | `on-change`    | A callback function that is called when the user makes a selection (e.g. by clicking on an item or on \"Add\" for custom item).
+   | `value`        | The initial value. Default is the empty string.
+   | `placeholder`  | The placeholder text for when an item has not yet been selected.
+   | `disabled`     | Is the combo box disabled? If so, the dropdown can't be opened."
+  [{:keys [id min on-change value placeholder disabled]
+    :or {id          (random-uuid)
+         disabled    false
+         value       ""
+         placeholder "Please make your selection"
+         on-change   identity}}]
+  (let [combo-box-ratom (r/atom {:current-value value
+                                 :dropdown {:open? false
+                                            :focus 0
+                                            :value nil}})
+        current-value   (r/cursor combo-box-ratom [:current-value])
+        dropdown-open?  (r/cursor combo-box-ratom [:dropdown :open?])
+        value-update-fn (fn [value]
+                          (reset! current-value value)
+                          (reset! dropdown-open? false)
+                          (on-change @current-value))
+        on-blur-fn      (fn [e]
+                          (when-not (fns/child-event? e)
+                            (reset! dropdown-open? false)))]
+    (fn []
+      (let [curr-label     (str @current-value)
+            #_#_on-key-down-fn (make-key-down-fn
+                                {:options         opts-coll
+                                 :dropdown-focus  dropdown-focus
+                                 :dropdown-open?  dropdown-open?
+                                 :value-update-fn value-update-fn
+                                 :space-select?   false})]
+        [:div
+         [:div {:id          id
+                :disabled    disabled
+                :tab-index   0
+                :class       "form-custom-select-input"
+                #_#_:on-key-down on-key-down-fn
+                :on-blur     on-blur-fn
+                :aria-label  "Combo Box Input"}
+          [select-input-top
+           {:id             id
+            :disabled       disabled
+            :dropdown-open? dropdown-open?
+            :label          curr-label
+            :placeholder    placeholder}]
+          (when (and (not disabled) @dropdown-open?)
+            [combo-box-numeric
+             {:id              id
+              :min             min
+              :dropdown-value  current-value
+              :value-update-fn value-update-fn}])]]))))
 
 ;; Action Dropdown ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -18,14 +18,16 @@
 (defn make-key-down-fn
   "Return an event callback function to use for `:on-key-down`."
   [{:keys [options dropdown-focus dropdown-open? on-enter space-select?]}]
-  (let [opts-count     (count options)
+  (let [options        (vec options) ; ensure options is a vector
+        opts-count     (count options)
         opts-dec-count (dec opts-count)
-        on-enter       (fn [_]
-                         (when (not-empty options)
+        on-enter       (if (not-empty options)
+                         (fn [_]
                            (-> options
                                (get @dropdown-focus)
                                :value
-                               on-enter)))
+                               on-enter))
+                         (fn [_] nil))
         on-up          (fn [e]
                          (when (<= 0 (dec @dropdown-focus))
                            (swap! dropdown-focus dec))

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -47,7 +47,7 @@
         :end       (on-pg-down e)
         nil))))
 
-(defn- get-label
+(defn get-label
   "Takes an options coll and a value and returns the label text"
   [opts val]
   (->> opts
@@ -123,7 +123,7 @@
 
 (defn select-input-top
   "The top pane of a (singleton) select input (including regular combo boxes)."
-  [{:keys [id disabled placeholder options current-value dropdown-open?]}]
+  [{:keys [id disabled label placeholder dropdown-open?]}]
   [:div {:id       (str id "-select-input")
          :name     (str id "-select-input")
          :class    (cond
@@ -132,11 +132,22 @@
                      :else           "form-select-top")
          :on-click #(when-not disabled (swap! dropdown-open? not))}
    [:span {:class "form-select-top-left"}
-    [:p (if-some [value @current-value]
-            ;; TODO: Better solution to value-label discrepancy
-          (or (get-label options value) value)
-          placeholder)]]
+    [:p (or label placeholder)]]
    [:span {:class "form-select-top-right"}
     [:img {:src (if @dropdown-open?
                   "images/icons/icon-expand-less.svg"
                   "images/icons/icon-expand-more.svg")}]]])
+
+(defn action-select-top
+  "The top pane of a select input with a custom dropdown icon."
+  [{:keys [label label-left? icon-src dropdown-open?]}]
+  [:div.action-dropdown-icon
+   [:a {:href "#"
+        :on-click (fn [e]
+                    (fns/ps-event e)
+                    (reset! dropdown-open? true))}
+    (when (and label label-left?)
+      [:span.action-dropdown-label (str label " ")])
+    [:img {:src icon-src}]
+    (when (and label (not label-left?))
+      [:span.action-dropdown-label (str " " label)])]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -66,6 +66,41 @@
        :label))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Top Component
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn select-input-top
+  "The top pane of a (singleton) select input (including regular combo boxes)."
+  [{:keys [id disabled label placeholder dropdown-open?]}]
+  [:div {:id       (str id "-select-input")
+         :name     (str id "-select-input")
+         :class    (cond
+                     disabled        "form-select-top disabled"
+                     @dropdown-open? "form-select-top opened"
+                     :else           "form-select-top")
+         :on-click #(when-not disabled (swap! dropdown-open? not))}
+   [:span {:class "form-select-top-left"}
+    [:p (or label placeholder)]]
+   [:span {:class "form-select-top-right"}
+    [:img {:src (if @dropdown-open?
+                  "images/icons/icon-expand-less.svg"
+                  "images/icons/icon-expand-more.svg")}]]])
+
+(defn action-select-top
+  "The top pane of a select input with a custom dropdown icon."
+  [{:keys [label label-left? icon-src dropdown-open?]}]
+  [:div.action-dropdown-icon
+   [:a {:href "#"
+        :on-click (fn [e]
+                    (fns/ps-event e)
+                    (reset! dropdown-open? true))}
+    (when (and label label-left?)
+      [:span.action-dropdown-label (str label " ")])
+    [:img {:src icon-src}]
+    (when (and label (not label-left?))
+      [:span.action-dropdown-label (str " " label)])]])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dropdown Component
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -83,7 +118,7 @@
    [:img {:src "images/icons/icon-add.svg"}]
    "Add"])
 
-(defn dropdown-items
+(defn items-dropdown
   "The list of items in a dropdown."
   [{:keys [id options dropdown-focus on-enter]}]
   (into [:ul {:id       (str id "-dropdown-items")
@@ -130,9 +165,9 @@
          :name  (str name "-dropdown")
          :class "form-select-dropdown"}
    [combo-box-search opts]
-   [dropdown-items opts]])
+   [items-dropdown opts]])
 
-(defn combo-box-numeric
+(defn numeric-dropdown
   [{:keys [min dropdown-value on-enter]}]
   (let [value-ref (r/atom @dropdown-value)]
     (fn [_]
@@ -146,38 +181,3 @@
                  :class     "form-text-input-with-side-button"}]
         [add-button {:dropdown-value value-ref
                      :on-enter       on-enter}]]])))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Top Component
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn select-input-top
-  "The top pane of a (singleton) select input (including regular combo boxes)."
-  [{:keys [id disabled label placeholder dropdown-open?]}]
-  [:div {:id       (str id "-select-input")
-         :name     (str id "-select-input")
-         :class    (cond
-                     disabled        "form-select-top disabled"
-                     @dropdown-open? "form-select-top opened"
-                     :else           "form-select-top")
-         :on-click #(when-not disabled (swap! dropdown-open? not))}
-   [:span {:class "form-select-top-left"}
-    [:p (or label placeholder)]]
-   [:span {:class "form-select-top-right"}
-    [:img {:src (if @dropdown-open?
-                  "images/icons/icon-expand-less.svg"
-                  "images/icons/icon-expand-more.svg")}]]])
-
-(defn action-select-top
-  "The top pane of a select input with a custom dropdown icon."
-  [{:keys [label label-left? icon-src dropdown-open?]}]
-  [:div.action-dropdown-icon
-   [:a {:href "#"
-        :on-click (fn [e]
-                    (fns/ps-event e)
-                    (reset! dropdown-open? true))}
-    (when (and label label-left?)
-      [:span.action-dropdown-label (str label " ")])
-    [:img {:src icon-src}]
-    (when (and label (not label-left?))
-      [:span.action-dropdown-label (str " " label)])]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -16,7 +16,7 @@
 
 (defn make-key-down-fn
   "Return an event callback function to use for `:on-key-down`."
-  [{:keys [options dropdown-focus dropdown-open? value-update-fn space-select?]}]
+  [{:keys [options dropdown-focus dropdown-open? on-enter space-select?]}]
   (let [opts-count     (count options)
         opts-dec-count (dec opts-count)
         on-enter       (fn [_]
@@ -24,7 +24,7 @@
                            (-> options
                                (get @dropdown-focus)
                                :value
-                               value-update-fn)))
+                               on-enter)))
         on-up          (fn [e]
                          (when (<= 0 (dec @dropdown-focus))
                            (swap! dropdown-focus dec))
@@ -69,13 +69,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- add-button
-  [{:keys [dropdown-value value-update-fn]}]
+  [{:keys [dropdown-value on-enter]}]
   [:span {:class       "side-button"
           :on-click    (fn [_]
-                         (value-update-fn @dropdown-value))
+                         (on-enter @dropdown-value))
           :on-key-down (fn [e]
                          (when (= :enter (fns/get-event-key e))
-                           (value-update-fn @dropdown-value)
+                           (on-enter @dropdown-value)
                            (fns/ps-event e)))
           :tab-index   0
           :aria-label  "Select the text in the search bar."}
@@ -84,7 +84,7 @@
 
 (defn dropdown-items
   "The list of items in a dropdown."
-  [{:keys [id options dropdown-focus value-update-fn]}]
+  [{:keys [id options dropdown-focus on-enter]}]
   (into [:ul {:id       (str id "-dropdown-items")
               :name     (str id "-dropdown-items")
               :class    "form-select-dropdown-items"}]
@@ -95,7 +95,7 @@
                                   "form-select-dropdown-item selected"
                                   "form-select-dropdown-item")
                  :on-mouse-over #(reset! dropdown-focus idx)
-                 :on-click      #(value-update-fn value)
+                 :on-click      #(on-enter value)
                  :aria-label    (str "Select the value " label)}
             [:p label]])
          options)))
@@ -103,7 +103,7 @@
 (defn- combo-box-search
   "The top combo box search bar."
   [{:keys
-    [id dropdown-value value-update-fn on-search]}]
+    [id dropdown-value on-enter on-search]}]
   (let [value-ref (r/atom @dropdown-value)]
     (fn [_]
       [:div
@@ -119,8 +119,8 @@
                  :id        (str id "-dropdown-search")
                  :name      (str id "-dropdown-search")
                  :class     "form-text-input-with-side-button"}]
-        [add-button {:dropdown-value  value-ref
-                     :value-update-fn value-update-fn}]]])))
+        [add-button {:dropdown-value value-ref
+                     :on-enter       on-enter}]]])))
 
 (defn combo-box-dropdown
   "A dropdown specific for combo boxes, including the search bar."
@@ -132,7 +132,7 @@
    [dropdown-items opts]])
 
 (defn combo-box-numeric
-  [{:keys [min dropdown-value value-update-fn]}]
+  [{:keys [min dropdown-value on-enter]}]
   (let [value-ref (r/atom @dropdown-value)]
     (fn [_]
       [:div {:class "form-select-dropdown"}
@@ -143,8 +143,8 @@
                  :min       min
                  :value     @value-ref
                  :class     "form-text-input-with-side-button"}]
-        [add-button {:dropdown-value  value-ref
-                     :value-update-fn value-update-fn}]]])))
+        [add-button {:dropdown-value value-ref
+                     :on-enter       on-enter}]]])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Top Component

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -140,38 +140,3 @@
     [:img {:src (if @dropdown-open?
                   "images/icons/icon-expand-less.svg"
                   "images/icons/icon-expand-more.svg")}]]])
-
-(defn multi-select-input-top
-  "The top pane of a multiple-selection combo box."
-  [{:keys [id disabled options current-value dropdown-open?
-           value-update-fn placeholder]}]
-  [:div {:id    (str id "-multi-select-input")
-         :name  (str id "-multi-select-input")
-         :class (if @dropdown-open?
-                  "form-multi-select-top opened"
-                  "form-multi-select-top")
-         ; We need two ps-event calls to stop propagation of onClick
-         ;; event from the div to the delete button
-         :on-click (fn [e]
-                     (when-not disabled
-                       (swap! dropdown-open? not)
-                       (fns/ps-event e)))}
-   [:div {:class "form-multi-select-top-left"}
-    (if-some [values (not-empty @current-value)]
-      (reduce
-       (fn [acc val]
-         (conj acc
-               [:span {:class "form-multi-select-array-item"}
-                ;; TODO: Better solution to value-label discrepancy
-                [:p (or (get-label options val) val)
-                 [:img {:src "images/icons/icon-close-black.svg"
-                        :on-click (fn [e]
-                                    (fns/ps-event e)
-                                    (value-update-fn val))}]]]))
-       [:span]
-       values)
-      [:p placeholder])]
-   [:div {:class "form-multi-select-top-right"}
-    [:img {:src (if @dropdown-open?
-                  "images/icons/icon-expand-less.svg"
-                  "images/icons/icon-expand-more.svg")}]]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -12,7 +12,8 @@
     (case (fns/get-event-key e)
       :space (when-not @dropdown-open?
                (reset! dropdown-open? true)
-               (fns/ps-event e)))))
+               (fns/ps-event e))
+      nil)))
 
 (defn make-key-down-fn
   "Return an event callback function to use for `:on-key-down`."

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -77,7 +77,7 @@
             [:p label]])
          options)))
 
-(defn combo-box-search
+(defn- combo-box-search
   "The top combo box search bar."
   [{:keys
     [id name dropdown-value value-update-fn search-update-fn custom-text?]}]
@@ -107,6 +107,15 @@
               :aria-label  "Select the text in the search bar."}
        [:img {:src "images/icons/icon-add.svg"}]
        "Add"])]])
+
+(defn combo-box-dropdown
+  "A dropdown specific for combo boxes, including the search bar."
+  [{:keys [id name] :as opts}]
+  [:div {:id    (str id "-dropdown")
+         :name  (str name "-dropdown")
+         :class "form-select-dropdown"}
+   [combo-box-search opts]
+   [dropdown-items opts]])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Top Component

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -68,6 +68,20 @@
 ;; Dropdown Component
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn- add-button
+  [{:keys [dropdown-value value-update-fn]}]
+  [:span {:class       "side-button"
+          :on-click    (fn [_]
+                         (value-update-fn @dropdown-value))
+          :on-key-down (fn [e]
+                         (when (= :enter (fns/get-event-key e))
+                           (value-update-fn @dropdown-value)
+                           (fns/ps-event e)))
+          :tab-index   0
+          :aria-label  "Select the text in the search bar."}
+   [:img {:src "images/icons/icon-add.svg"}]
+   "Add"])
+
 (defn dropdown-items
   "The list of items in a dropdown."
   [{:keys [id options dropdown-focus value-update-fn]}]
@@ -102,17 +116,8 @@
              :id        (str id "-dropdown-search")
              :name      (str id "-dropdown-search")
              :class     "form-text-input-with-side-button"}]
-    [:span {:class       "side-button"
-            :on-click    (fn [_]
-                           (value-update-fn @dropdown-value))
-            :on-key-down (fn [e]
-                           (when (= :enter (fns/get-event-key e))
-                             (value-update-fn @dropdown-value)
-                             (fns/ps-event e)))
-            :tab-index   0
-            :aria-label  "Select the text in the search bar."}
-     [:img {:src "images/icons/icon-add.svg"}]
-     "Add"]]])
+    [add-button {:dropdown-value  dropdown-value
+                 :value-update-fn value-update-fn}]]])
 
 (defn combo-box-dropdown
   "A dropdown specific for combo boxes, including the search bar."
@@ -135,17 +140,8 @@
                  :min       min
                  :value     @value-ref
                  :class     "form-text-input-with-side-button"}]
-        [:span {:class       "side-button"
-                :on-click    (fn [_]
-                               (value-update-fn @value-ref))
-                :on-key-down (fn [e]
-                               (when (= :enter (fns/get-event-key e))
-                                 (value-update-fn @value-ref)
-                                 (fns/ps-event e)))
-                :tab-index   0
-                :aria-label  "Select the text in the search bar."}
-         [:img {:src "images/icons/icon-add.svg"}]
-         "Add"]]])))
+        [add-button {:dropdown-value  value-ref
+                     :value-update-fn value-update-fn}]]])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Top Component

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -77,7 +77,7 @@
             [:p label]])
          options)))
 
-(defn- combo-box-search
+(defn combo-box-search
   "The top combo box search bar."
   [{:keys
     [id name dropdown-value value-update-fn search-update-fn custom-text?]}]
@@ -107,15 +107,6 @@
               :aria-label  "Select the text in the search bar."}
        [:img {:src "images/icons/icon-add.svg"}]
        "Add"])]])
-
-(defn combo-box-dropdown
-  "A dropdown specific for combo boxes, including the search bar."
-  [{:keys [id name] :as opts}]
-  [:div {:id    (str id "-dropdown")
-         :name  (str name "-dropdown")
-         :class "form-select-dropdown"}
-   [combo-box-search opts]
-   [dropdown-items opts]])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Top Component

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -61,9 +61,9 @@
 
 (defn dropdown-items
   "The list of items in a dropdown."
-  [{:keys [id name options dropdown-focus value-update-fn]}]
+  [{:keys [id options dropdown-focus value-update-fn]}]
   (into [:ul {:id       (str id "-dropdown-items")
-              :name     (str name "-dropdown-items")
+              :name     (str id "-dropdown-items")
               :class    "form-select-dropdown-items"}]
         (map-indexed
          (fn [idx {:keys [value label]}]
@@ -80,7 +80,7 @@
 (defn- combo-box-search
   "The top combo box search bar."
   [{:keys
-    [id name dropdown-value value-update-fn search-update-fn custom-text?]}]
+    [id dropdown-value value-update-fn search-update-fn custom-text?]}]
   [:div
    [:div {:class "form-select-dropdown-search-label"}
     (if custom-text? [:p "Search or Add:"] [:p "Search:"])]
@@ -91,7 +91,7 @@
              :type      "text"
              :value     @dropdown-value
              :id        (str id "-dropdown-search")
-             :name      (str name "-dropdown-search")
+             :name      (str id "-dropdown-search")
              :class     (if custom-text?
                           "form-text-input-with-side-button"
                           "form-text-input")}]
@@ -123,9 +123,9 @@
 
 (defn select-input-top
   "The top pane of a (singleton) select input (including regular combo boxes)."
-  [{:keys [id name disabled placeholder options current-value dropdown-open?]}]
+  [{:keys [id disabled placeholder options current-value dropdown-open?]}]
   [:div {:id       (str id "-select-input")
-         :name     (str name "-select-input")
+         :name     (str id "-select-input")
          :class    (cond
                      disabled        "form-select-top disabled"
                      @dropdown-open? "form-select-top opened"
@@ -143,10 +143,10 @@
 
 (defn multi-select-input-top
   "The top pane of a multiple-selection combo box."
-  [{:keys [id name disabled options current-value dropdown-open?
+  [{:keys [id disabled options current-value dropdown-open?
            value-update-fn placeholder]}]
   [:div {:id    (str id "-multi-select-input")
-         :name  (str name "-multi-select-input")
+         :name  (str id "-multi-select-input")
          :class (if @dropdown-open?
                   "form-multi-select-top opened"
                   "form-multi-select-top")

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -103,21 +103,24 @@
 (defn- combo-box-search
   "The top combo box search bar."
   [{:keys
-    [id dropdown-value value-update-fn search-update-fn]}]
-  [:div
-   [:div {:class "form-select-dropdown-search-label"}
-    [:p "Search or Add:"]]
-   [:div {:class "form-select-dropdown-search-box"}
-    [:input {:on-change (fn [x]
-                          (reset! dropdown-value (fns/ps-event-val x))
-                          (search-update-fn @dropdown-value))
-             :type      "text"
-             :value     @dropdown-value
-             :id        (str id "-dropdown-search")
-             :name      (str id "-dropdown-search")
-             :class     "form-text-input-with-side-button"}]
-    [add-button {:dropdown-value  dropdown-value
-                 :value-update-fn value-update-fn}]]])
+    [id dropdown-value value-update-fn on-search]}]
+  (let [value-ref (r/atom @dropdown-value)]
+    (fn [_]
+      [:div
+       [:div {:class "form-select-dropdown-search-label"}
+        [:p "Search or Add:"]]
+       [:div {:class "form-select-dropdown-search-box"}
+        [:input {:on-change (fn [x]
+                              (let [v (fns/ps-event-val x)]
+                                (reset! value-ref v)
+                                (on-search v)))
+                 :type      "text"
+                 :value     @value-ref
+                 :id        (str id "-dropdown-search")
+                 :name      (str id "-dropdown-search")
+                 :class     "form-text-input-with-side-button"}]
+        [add-button {:dropdown-value  value-ref
+                     :value-update-fn value-update-fn}]]])))
 
 (defn combo-box-dropdown
   "A dropdown specific for combo boxes, including the search bar."

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -118,7 +118,8 @@
                            (fns/ps-event e)))
           :tab-index   0
           :aria-label  "Select the text in the search bar."}
-   [:img {:src "images/icons/icon-add.svg"}]])
+   [:img {:src "images/icons/icon-add.svg"}]
+   "Add"])
 
 (defn items-dropdown
   "The list of items in a dropdown."

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -89,10 +89,10 @@
 (defn- combo-box-search
   "The top combo box search bar."
   [{:keys
-    [id dropdown-value value-update-fn search-update-fn custom-text?]}]
+    [id dropdown-value value-update-fn search-update-fn]}]
   [:div
    [:div {:class "form-select-dropdown-search-label"}
-    (if custom-text? [:p "Search or Add:"] [:p "Search:"])]
+    [:p "Search or Add:"]]
    [:div {:class "form-select-dropdown-search-box"}
     [:input {:on-change (fn [x]
                           (reset! dropdown-value (fns/ps-event-val x))
@@ -101,21 +101,18 @@
              :value     @dropdown-value
              :id        (str id "-dropdown-search")
              :name      (str id "-dropdown-search")
-             :class     (if custom-text?
-                          "form-text-input-with-side-button"
-                          "form-text-input")}]
-    (when custom-text?
-      [:span {:class       "side-button"
-              :on-click    (fn [_]
-                             (value-update-fn @dropdown-value))
-              :on-key-down (fn [e]
-                             (when (= :enter (fns/get-event-key e))
-                               (value-update-fn @dropdown-value)
-                               (fns/ps-event e)))
-              :tab-index   0
-              :aria-label  "Select the text in the search bar."}
-       [:img {:src "images/icons/icon-add.svg"}]
-       "Add"])]])
+             :class     "form-text-input-with-side-button"}]
+    [:span {:class       "side-button"
+            :on-click    (fn [_]
+                           (value-update-fn @dropdown-value))
+            :on-key-down (fn [e]
+                           (when (= :enter (fns/get-event-key e))
+                             (value-update-fn @dropdown-value)
+                             (fns/ps-event e)))
+            :tab-index   0
+            :aria-label  "Select the text in the search bar."}
+     [:img {:src "images/icons/icon-add.svg"}]
+     "Add"]]])
 
 (defn combo-box-dropdown
   "A dropdown specific for combo boxes, including the search bar."

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -6,6 +6,14 @@
 ;; Helpers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn make-key-down-fn*
+  [{:keys [dropdown-open?]}]
+  (fn [e]
+    (case (fns/get-event-key e)
+      :space (when-not @dropdown-open?
+               (reset! dropdown-open? true)
+               (fns/ps-event e)))))
+
 (defn make-key-down-fn
   "Return an event callback function to use for `:on-key-down`."
   [{:keys [options dropdown-focus dropdown-open? value-update-fn space-select?]}]

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -1,5 +1,6 @@
 (ns com.yetanalytics.lrs-admin-ui.views.form.dropdown
   (:require [reagent.core :as r]
+            [re-frame.core :refer [subscribe]]
             [com.yetanalytics.lrs-admin-ui.functions :as fns]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -146,7 +147,7 @@
     (fn [_]
       [:div
        [:div {:class "form-select-dropdown-search-label"}
-        [:p "Search or Add:"]]
+        [:p @(subscribe [:lang/get :form.search-or-add])]]
        [:div {:class "form-select-dropdown-search-box"}
         [:input {:on-change (fn [x]
                               (let [v (fns/ps-event-val x)]
@@ -174,6 +175,8 @@
   (let [value-ref (r/atom @dropdown-value)]
     (fn [_]
       [:div {:class "form-select-dropdown"}
+       [:div {:class "form-select-dropdown-search-label"}
+        [:p @(subscribe [:lang/get :form.add])]]
        [:div {:class "form-select-dropdown-search-box"}
         [:input {:on-change (fn [x]
                               (reset! value-ref (fns/ps-event-val x)))

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -118,8 +118,7 @@
                            (fns/ps-event e)))
           :tab-index   0
           :aria-label  "Select the text in the search bar."}
-   [:img {:src "images/icons/icon-add.svg"}]
-   "Add"])
+   [:img {:src "images/icons/icon-add.svg"}]])
 
 (defn items-dropdown
   "The list of items in a dropdown."

--- a/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/form/dropdown.cljs
@@ -1,5 +1,6 @@
 (ns com.yetanalytics.lrs-admin-ui.views.form.dropdown
-  (:require [com.yetanalytics.lrs-admin-ui.functions :as fns]))
+  (:require [reagent.core :as r]
+            [com.yetanalytics.lrs-admin-ui.functions :as fns]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helpers
@@ -116,6 +117,30 @@
          :class "form-select-dropdown"}
    [combo-box-search opts]
    [dropdown-items opts]])
+
+(defn combo-box-numeric
+  [{:keys [min dropdown-value value-update-fn]}]
+  (let [value-ref (r/atom @dropdown-value)]
+    (fn [_]
+      [:div {:class "form-select-dropdown"}
+       [:div {:class "form-select-dropdown-search-box"}
+        [:input {:on-change (fn [x]
+                              (reset! value-ref (fns/ps-event-val x)))
+                 :type      "number"
+                 :min       min
+                 :value     @value-ref
+                 :class     "form-text-input-with-side-button"}]
+        [:span {:class       "side-button"
+                :on-click    (fn [_]
+                               (value-update-fn @value-ref))
+                :on-key-down (fn [e]
+                               (when (= :enter (fns/get-event-key e))
+                                 (value-update-fn @value-ref)
+                                 (fns/ps-event e)))
+                :tab-index   0
+                :aria-label  "Select the text in the search bar."}
+         [:img {:src "images/icons/icon-add.svg"}]
+         "Add"]]])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Top Component

--- a/src/com/yetanalytics/lrs_admin_ui/views/reactions.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/reactions.cljs
@@ -676,18 +676,25 @@
    {:keys [identityPaths
            conditions
            template]}]
-  [:dl.reaction-ruleset
-   [:dt @(subscribe [:lang/get :reactions.details.ruleset.conditions])
+  ;; Cannot use <dl> elements here since that would cause DOM nesting errors
+  [:div.reaction-ruleset {:id "ruleset-view"}
+   ;; TODO: Properly redo divs to remove extraneous nesting
+   [:label {:for "reaction-ruleset-conditions"}
+    @(subscribe [:lang/get :reactions.details.ruleset.conditions])
     [tooltip-info {:value @(subscribe [:lang/get :tooltip.reactions.ruleset.conditions])}]]
-   [:dd
+   [:div {:id "reaction-ruleset-conditions"}
     (when (contains? #{:edit :new} mode)
       [render-conditions-errors conditions])
     [render-conditions mode conditions]
     (when (contains? #{:edit :new} mode)
       [add-condition :to-add-desc ""])]
-   [:dt @(subscribe [:lang/get :reactions.template.title])
+   
+   [:label {:for "reaction-ruleset-templates"}
+    @(subscribe [:lang/get :reactions.template.title])
     [tooltip-info {:value @(subscribe [:lang/get :tooltip.reactions.template])}]]
-   [:dd [t/render-or-edit-template mode template]]
+   [:div {:id "reaction-ruleset-conditions"}
+    [t/render-or-edit-template mode template]]
+   
    [render-identity-paths
     mode identityPaths]])
 
@@ -818,10 +825,10 @@
           [:<>
            [:dt @(subscribe [:lang/get :reactions.details.created])]
            [:dd (or (iso8601->local-display created) "[New]")]
-       
+
            [:dt @(subscribe [:lang/get :reactions.details.modified])]
            [:dd (or (iso8601->local-display modified) "[New]")]
-       
+
            [:dt @(subscribe [:lang/get :reactions.details.error])]
            [:dd [render-error error]]])]
        [:dt @(subscribe [:lang/get :reactions.details.title])
@@ -843,9 +850,10 @@
         (case mode
           :focus (if active "Active" "Inactive")
           [edit-status active])]
-
-       [:dt @(subscribe [:lang/get :reactions.details.ruleset])]
-       [:dd [ruleset-view mode ruleset]]]
+       
+       [:label {:for "ruleset-view"}
+        @(subscribe [:lang/get :reactions.details.ruleset])]
+       [ruleset-view mode ruleset]]
       [reaction-actions mode id error?]]]))
 
 (defn reactions

--- a/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
@@ -23,7 +23,7 @@
         v)
       parsed-int)))
 
-(defn- next-key-options [next-key-opts search-str]
+(defn- next-key-options-filter [next-key-opts search-str]
   (->> next-key-opts
        (filter (fn [{:keys [value]}] (cstr/starts-with? value search-str)))
        rfns/order-select-entries))
@@ -35,8 +35,10 @@
          seg-val
          change-fn]
       (let [id (str (random-uuid))
-            {:keys [next-keys]} (rpath/analyze-path
-                                 path-until)]
+            {:keys [next-keys]} (rpath/analyze-path path-until)
+            next-key-options (->> next-keys
+                                  (map (fn [k] {:label k :value k}))
+                                  rfns/order-select-entries)]
         [:div.path-input-segment-edit
          [:div.segment-combo
           (if (= '[idx] next-keys)
@@ -56,9 +58,9 @@
                               (change-fn (parse-selection v)))
               :on-search    (fn [v] (reset! search v))
               :options-fn   (fn []
-                              (next-key-options next-keys @search))
-              :on-filter    next-key-options
-              :options      (mapv (fn [k] {:label k :value k}) next-keys)
+                              (next-key-options-filter next-keys @search))
+              :on-filter    next-key-options-filter
+              :options      next-key-options
               :value        seg-val
               :placeholder  "(select)"
               :disabled     false

--- a/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
@@ -4,7 +4,8 @@
             [com.yetanalytics.lrs-reactions.path :as rpath]
             [com.yetanalytics.lrs-admin-ui.views.form :as form]
             [goog.string :refer [format]]
-            [goog.string.format]))
+            [goog.string.format]
+            [com.yetanalytics.lrs-admin-ui.functions.reaction :as rfns]))
 
 (defn- path-input-segment
   [seg-val]
@@ -55,9 +56,10 @@
                   ;; index expected
                   (for [idx (range 10)]
                     {:label (str idx) :value idx})
-                  (for [k next-keys
-                        :when (.startsWith k @search)]
-                    {:label k :value k})))
+                  (rfns/order-select-entries
+                   (for [k next-keys
+                         :when (.startsWith k @search)]
+                     {:label k :value k}))))
               ;; :tooltip "I'M A TOOLTIP OVA HEA" ;; NOT YET IMPLEMENTED, MIGHT NEVER BE
               ;; :required true
               :removable? false}]])]))))

--- a/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
@@ -1,5 +1,6 @@
 (ns com.yetanalytics.lrs-admin-ui.views.reactions.path
   (:require [reagent.core :as r]
+            [clojure.string :as cstr]
             [com.yetanalytics.lrs-admin-ui.functions :as fns]
             [com.yetanalytics.lrs-reactions.path :as rpath]
             [com.yetanalytics.lrs-admin-ui.views.form :as form]
@@ -22,15 +23,10 @@
         v)
       parsed-int)))
 
-(defn- next-key-options [next-keys search-str]
-  (if (= ['idx] next-keys)
-    ;; index expected (should never happen)
-    (for [idx (range 10)]
-      {:label (str idx) :value idx})
-    (rfns/order-select-entries
-     (for [k next-keys
-           :when (.startsWith k search-str)]
-       {:label k :value k}))))
+(defn- next-key-options [next-key-opts search-str]
+  (->> next-key-opts
+       (filter (fn [{:keys [value]}] (cstr/starts-with? value search-str)))
+       rfns/order-select-entries))
 
 (defn- path-input-segment-edit
   [_ _ _]
@@ -61,6 +57,8 @@
               :on-search    (fn [v] (reset! search v))
               :options-fn   (fn []
                               (next-key-options next-keys @search))
+              :on-filter    next-key-options
+              :options      (mapv (fn [k] {:label k :value k}) next-keys)
               :value        seg-val
               :placeholder  "(select)"
               :disabled     false

--- a/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
@@ -24,7 +24,7 @@
 
 (defn- next-key-options [next-keys search-str]
   (if (= ['idx] next-keys)
-    ;; index expected
+    ;; index expected (should never happen)
     (for [idx (range 10)]
       {:label (str idx) :value idx})
     (rfns/order-select-entries
@@ -42,16 +42,17 @@
             {:keys [next-keys]} (rpath/analyze-path
                                  path-until)]
         [:div.path-input-segment-edit
-         (if (= '[idx] next-keys)
-           ;; When we know it is an index, use a numeric input
-           [:input.index
-            {:type "number"
-             :min "0"
-             :value seg-val
-             :on-change (fn [e]
-                          (fns/ps-event e)
-                          (change-fn (js/parseInt (fns/ps-event-val e))))}]
-           [:div.segment-combo
+         [:div.segment-combo
+          (if (= '[idx] next-keys)
+            ;; When we know it is an index, use a numeric input
+            [form/combo-box-numeric-input
+             {:id          id
+              :min         "0"
+              :on-change   (fn [v]
+                             (change-fn (parse-selection v)))
+              :value       seg-val
+              :placeholder "(select)"
+              :disabled    false}]
             [form/combo-box-input
              {:id           id
               :name         (format "combo-%s" id)
@@ -65,7 +66,7 @@
               :disabled     false
               :custom-text? true
               ;; :tooltip "I'M A TOOLTIP OVA HEA" ;; NOT YET IMPLEMENTED, MIGHT NEVER BE
-              }]])]))))
+              }])]]))))
 
 (defn path-input
   [path

--- a/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
@@ -40,7 +40,9 @@
                            ;; If it can be an int, pass it as such
                            (let [parsed-int (js/parseInt v)]
                              (if (js/isNaN parsed-int)
-                               (change-fn v)
+                               (if (nil? v)
+                                 (change-fn "")
+                                 (change-fn v))
                                (change-fn parsed-int))))
               :on-search (fn [v] (reset! search v))
               :value seg-val

--- a/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
@@ -79,11 +79,13 @@
            del-fn (fn [_] (println 'del))
            change-fn (fn [_] (println 'change))
            validate? true}}]
-  (let [{:keys [complete? valid?]} (rpath/analyze-path path)]
+  (let [{:keys [complete? valid? leaf-type]} (rpath/analyze-path path)
+        valid-path? (and validate?
+                         (or (not valid?)
+                             (and (not= 'json leaf-type) ; disregard extensions
+                                  (not complete?))))]
     (-> [:div.path-input
-         {:class (when (and validate?
-                            (or (not valid?) (not complete?)))
-                   "invalid")}
+         {:class (when valid-path? "invalid")}
          [:div.path-input-root
           "$"]]
         ;; Intermediate path

--- a/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
@@ -14,24 +14,6 @@
      (format "[%s]" seg-val)
      (str seg-val))])
 
-(defn- parse-path-segment-selection [v]
-  (let [parsed-int (js/parseInt v)]
-    (if (js/isNaN parsed-int)
-      (if (nil? v)
-        ""
-        v)
-      parsed-int)))
-
-(defn- path-segment-options [next-keys search-str]
-  (if (= ['idx] next-keys)
-    ;; index expected
-    (for [idx (range 10)]
-      {:label (str idx) :value idx})
-    (rfns/order-select-entries
-     (for [k next-keys
-           :when (.startsWith k search-str)]
-       {:label k :value k}))))
-
 (defn- path-input-segment-edit
   [_ _ _]
   (let [search (r/atom "")]
@@ -42,7 +24,7 @@
             {:keys [next-keys]} (rpath/analyze-path
                                  path-until)]
         [:div.path-input-segment-edit
-         (if false #_(= '[idx] next-keys)
+         (if (= '[idx] next-keys)
            ;; When we know it is an index, use a numeric input
            [:input.index
             {:type "number"
@@ -53,21 +35,34 @@
                           (change-fn (js/parseInt (fns/ps-event-val e))))}]
            [:div.segment-combo
             [form/combo-box-input
-             {:id           id
-              :name         (format "combo-%s" id)
-              :on-search    (fn [v] (reset! search v))
-              :on-change    (fn [v]
-                              (change-fn (parse-path-segment-selection v)))
-              :options-fn   (fn []
-                              (path-segment-options next-keys @search))
-              :value        seg-val
-              :placeholder  "(select)"
-              :disabled     false
+             {:id id
+              :name (format "combo-%s" id)
+              :on-change (fn [v]
+                           ;; If it can be an int, pass it as such
+                           (let [parsed-int (js/parseInt v)]
+                             (if (js/isNaN parsed-int)
+                               (if (nil? v)
+                                 (change-fn "")
+                                 (change-fn v))
+                               (change-fn parsed-int))))
+              :on-search (fn [v] (reset! search v))
+              :value seg-val
+              :placeholder "(select)"
+              :disabled false
               :custom-text? true
+              :options-fn
+              (fn []
+                (if (= ['idx] next-keys)
+                  ;; index expected
+                  (for [idx (range 10)]
+                    {:label (str idx) :value idx})
+                  (rfns/order-select-entries
+                   (for [k next-keys
+                         :when (.startsWith k @search)]
+                     {:label k :value k}))))
               ;; :tooltip "I'M A TOOLTIP OVA HEA" ;; NOT YET IMPLEMENTED, MIGHT NEVER BE
               ;; :required true
-              :removable?   false}
-             form/combo-box-dropdown]])]))))
+              :removable? false}]])]))))
 
 (defn path-input
   [path

--- a/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/reactions/path.cljs
@@ -41,7 +41,7 @@
          [:div.segment-combo
           (if (= '[idx] next-keys)
             ;; When we know it is an index, use a numeric input
-            [form/combo-box-numeric-input
+            [form/numeric-input
              {:id          id
               :min         "0"
               :on-change   (fn [v]


### PR DESCRIPTION
Fix the following bugs in the reaction UI:
- DOM nesting error due to nested `<dl>` elements
- Condition values are sometimes erased when completing statement path selection
- Statement path selector does not automatically offer new path segment after first changing the condition name
- Cannot add array indexes without path input moving on to the next segment; this is fixed with new numeric input
- Extensions paths are always marked as invalid despite actually being valid, preventing users from saving reactions with extension paths

In addition, perform the following enhancements:
- New conditions are now added to the bottom instead of the top of the list
- Typing used to be blocked when trying to input a duplicate condition name; this is now replaced with an error warning
- Add additional `:lang/get` keywords in the text map, for new errors + form inputs

To do this, the following major refactors were made:
- The reaction edit buffer spec now stores conditions as a vector instead of a map; this ensures stability when editing condition names
- Major changes to the dropdown code, including removing code unused in lrs-admin-ui and adding the new numeric path segment input