### PR TITLE
[SQL-264] JWT enhancements

### DIFF
--- a/src/com/yetanalytics/lrs_admin_ui/db.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/db.cljs
@@ -191,6 +191,7 @@
                           ::login
                           ::browser
                           ::accounts
+                          ::new-account
                           ::server-host
                           ::xapi-prefix
                           ::proxy-path

--- a/src/com/yetanalytics/lrs_admin_ui/db.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/db.cljs
@@ -186,6 +186,8 @@
 
 (s/def ::no-val-logout-url string?)
 
+(s/def ::last-interaction-time int?)
+
 (s/def ::db (s/keys :req [::session
                           ::credentials
                           ::login
@@ -206,7 +208,8 @@
                           ::status
                           ::update-password
                           ::enable-reactions
-                          ::reactions]
+                          ::reactions
+                          ::last-interaction-time]
                     :opt [::reaction-focus
                           ::editing-reaction
                           ::editing-reaction-template-errors

--- a/src/com/yetanalytics/lrs_admin_ui/db.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/db.cljs
@@ -186,7 +186,8 @@
 
 (s/def ::no-val-logout-url string?)
 
-(s/def ::jwt-exp-time int?)
+(s/def ::jwt-refresh-interval int?)
+(s/def ::jwt-interaction-window int?)
 (s/def ::last-interaction-time int?)
 
 (s/def ::db (s/keys :req [::session
@@ -210,7 +211,8 @@
                           ::update-password
                           ::enable-reactions
                           ::reactions
-                          ::jwt-exp-time
+                          ::jwt-refresh-interval
+                          ::jwt-interaction-window
                           ::last-interaction-time]
                     :opt [::reaction-focus
                           ::editing-reaction

--- a/src/com/yetanalytics/lrs_admin_ui/db.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/db.cljs
@@ -186,6 +186,7 @@
 
 (s/def ::no-val-logout-url string?)
 
+(s/def ::jwt-exp-time int?)
 (s/def ::last-interaction-time int?)
 
 (s/def ::db (s/keys :req [::session
@@ -209,6 +210,7 @@
                           ::update-password
                           ::enable-reactions
                           ::reactions
+                          ::jwt-exp-time
                           ::last-interaction-time]
                     :opt [::reaction-focus
                           ::editing-reaction

--- a/src/com/yetanalytics/lrs_admin_ui/functions/http.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/functions/http.cljs
@@ -38,10 +38,19 @@
 
 
 ;;JWTs
-(defn add-jwt [{:keys [headers] :as request}]
-  (assoc request :headers
-         (conj headers {"Authorization"
-                        (format "Bearer %s" @(subscribe [:session/get-token]))})))
+
+(defn add-jwt* [token {:keys [headers] :as request}]
+  (assoc request
+         :headers
+         (conj headers {"Authorization" (format "Bearer %s" token)})))
+
+(defn add-jwt [request]
+  (let [token @(subscribe [:session/get-token])]
+    (add-jwt* token request)))
+
+(defn add-jwt-interceptor* [token]
+  (to-interceptor {:name "JWT Authentication Interceptor"
+                   :request (partial add-jwt* token)}))
 
 (def add-jwt-interceptor
   (to-interceptor {:name "JWT Authentication Interceptor"

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -194,14 +194,34 @@
 ;; Login / Auth
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(def placeholder-token
+  "Sample token used for testing no-val JWT mode. This token has this body:
+   ```
+   {
+     \"domain\": \"https://unsecure.yetanalytics.com/realm\",
+     \"perms\": [\"ADMIN\"],
+     \"username\": \"CLIFF.CASEY.1234567890\"
+   }
+   ```
+   which correspond to the following values in lrsql config:
+   ```
+   {
+     \"jwtNoVal\": true,
+     \"jwtNoValUname\": \"username\",
+     \"jwtNoValIssuer\": \"domain\",
+     \"jwtNoValRoleKey\": \"perms\",
+     \"jwtNoValRole\": \"ADMIN\"
+   }
+   ```
+   "
+  "eyJhbGciOiJIUzI1NiJ9.eyJkb21haW4iOiJodHRwczovL3Vuc2VjdXJlLnlldGFuYWx5dGljcy5jb20vcmVhbG0iLCJwZXJtcyI6WyJBRE1JTiJdLCJ1c2VybmFtZSI6IkNMSUZGLkNBU0VZLjEyMzQ1Njc4OTAifQ.2gRn_tDFBfJx2RE0pgvPM4wH__RnHf1E9kjsNlkLrnQ")
+
 (re-frame/reg-event-fx
  :session/proxy-token-init
  (fn [_ _]
    ;; In this mode the token will be overwritten, so just store something and
-   ;; move on. For testing the feature, this placeholder token has "username",
-   ;; "perms" array containing "ADMIN" perm, and "domain" as the issuer
-   (let [placeholder-token "eyJhbGciOiJIUzI1NiJ9.eyJkb21haW4iOiJodHRwczovL3Vuc2VjdXJlLnlldGFuYWx5dGljcy5jb20vcmVhbG0iLCJwZXJtcyI6WyJBRE1JTiJdLCJ1c2VybmFtZSI6IkNMSUZGLkNBU0VZLjEyMzQ1Njc4OTAifQ.2gRn_tDFBfJx2RE0pgvPM4wH__RnHf1E9kjsNlkLrnQ"]
-     {:fx [[:dispatch [:session/set-token placeholder-token]]]})))
+   ;; move on.
+   {:fx [[:dispatch [:session/set-token placeholder-token]]]}))
 
 (re-frame/reg-event-db
  :login/set-username

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -121,11 +121,7 @@
                                      stmt-get-max
                                      custom-language]
                        ?oidc        :oidc
-                       ?oidc-enable :oidc-enable-local-admin
-                       :as env}]]
-                       (println env)
-   (println "JWT refresh interval:" jwt-refresh-interval)
-   (println "JWT interaction window:" jwt-interaction-window)
+                       ?oidc-enable :oidc-enable-local-admin}]]
    (let [jwt-refresh-interval*    (* 1000 jwt-refresh-interval)
          jwt-interaction-window*  (* 1000 jwt-interaction-window)
          oidc-enable-local-admin? (or ?oidc-enable false)

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -239,13 +239,6 @@
            [:dispatch-later {:ms       jwt-refresh-interval
                              :dispatch [:login/try-renew]}]]})))
 
-(comment
-  "Login JWT:
-   eyJhbGciOiJIUzI1NiJ9.eyJhY2MiOiIwMTkzMWM5Yi0yMDEwLTg3ZTMtOGY0MC1kYmJjM2E0Nzk0ZGIiLCJpYXQiOjE3MzEzNTIxNjEsImV4cCI6MTczMTM1NTc2MX0.scOscENM3-pvwYc2TOUS2IvN8RMO6Uww_lnFq2pP9FE"
-  
-  "Current JWT:
-   eyJhbGciOiJIUzI1NiJ9.eyJhY2MiOiIwMTkzMWM5Yi0yMDEwLTg3ZTMtOGY0MC1kYmJjM2E0Nzk0ZGIiLCJpYXQiOjE3MzEzNTIxNjEsImV4cCI6MTczMTM1NTc2MX0.scOscENM3-pvwYc2TOUS2IvN8RMO6Uww_lnFq2pP9FE")
-
 (re-frame/reg-event-fx
  :session/set-token
  (fn [{:keys [db]} [_ token & {:keys [store?]

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -399,7 +399,8 @@
  (fn [_ [_ {:keys [status] :as error}]]
    (if (= 401 status)
      {:fx [[:dispatch [:notification/notify true
-                       "Congratulations on being SQL LRS's biggest fan!"]]]}
+                       "Congratulations on being SQL LRS's biggest fan!"]]
+           [:dispatch [:session/logout]]]}
      {:fx [[:dispatch [:server-error error]]]})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -338,7 +338,7 @@
                        "An unexpected error has occured!")]
      {:fx (cond-> [[:dispatch [:notification/notify true message]]]
             (some #(= status %) [0 401])
-            (merge [:dispatch [:session/set-token nil]]))})))
+            (merge [:dispatch [:session/clear-token]]))})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Logout + Renewal

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -24,8 +24,28 @@
             [com.yetanalytics.lrs-admin-ui.language           :as lang]
             [com.yetanalytics.lrs-reactions.path              :as rpath]))
 
+(def interaction-interceptor
+  (re-frame/on-changes
+   (fn [& _] (.now js/Date))
+   [::db/last-interaction-time]
+   ;; Places in app-db to detect changes
+   [::db/session :page]
+   [::db/login]
+   [::db/credentials]
+   [::db/accounts]
+   [::db/new-account]
+   [::db/browser]
+   [::db/status]
+   [::db/reactions]
+   [::db/reaction-focus]
+   [::db/editing-reaction]
+   [::db/editing-reaction-template-json]))
+
 (re-frame/reg-global-interceptor
  db/check-spec-interceptor)
+
+(re-frame/reg-global-interceptor
+ interaction-interceptor)
 
 (re-frame/reg-event-fx
  :db/init

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -363,9 +363,14 @@
  (fn [{:keys [db]}]
    (let [{int-window    ::db/jwt-interaction-window
           last-int-time ::db/last-interaction-time} db
-         current-time (.now js/Date)]
-     (if (< (- current-time int-window) last-int-time current-time)
+         current-token (get-in db [::db/session :token])
+         current-time  (.now js/Date)]
+     (cond
+       (nil? current-token) ; logged out or non-JWT login
+       {}
+       (< (- current-time int-window) last-int-time current-time)
        {:fx [[:dispatch [:login/renew]]]}
+       :else
        {:fx [[:dispatch [:session/logout]]]}))))
 
 (re-frame/reg-event-fx

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -80,7 +80,8 @@
          ::db/enable-admin-status false
          ::db/status {}
          ::db/enable-reactions false
-         ::db/reactions []}
+         ::db/reactions []
+         ::db/last-interaction-time (.now js/Date)}
     :fx [[:dispatch [:db/get-env]]]}))
 
 (re-frame/reg-event-fx

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -25,6 +25,9 @@
             [com.yetanalytics.lrs-reactions.path              :as rpath]))
 
 (def interaction-interceptor
+  "Update `::db/last-interaction-time` to the current time whenever a change is
+   made to the specified paths to the app-db. This is a heuristic that will
+   detect some, but not all, user interactions with the UI."
   (re-frame/on-changes
    (fn [& _] (.now js/Date))
    [::db/last-interaction-time]

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -53,9 +53,10 @@
 (re-frame/reg-event-fx
  :db/init
  (fn [_  [_ server-host]]
-   {:db {::db/session {:page :credentials
-                       :token nil #_(stor/get-item "lrs-jwt")
-                       :username nil #_(stor/get-item "username")}
+   {:db {::db/session {:page     :credentials
+                       ;; Token and username will be set in `:db/verify-login`
+                       :token    nil
+                       :username nil}
          ::db/login {:username nil
                      :password nil}
          ::db/credentials []

--- a/src/com/yetanalytics/lrs_admin_ui/views/data_management/delete_actor.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/data_management/delete_actor.cljs
@@ -20,7 +20,7 @@
 (defn delete-actor []
   (let [ifi-types ["mbox" "mbox_sha1sum" "openid" "account"]
         ifi-type (r/atom (first ifi-types))
-        input (r/atom nil)]
+        input (r/atom nil)] ; TODO: Store in an app-db buffer
     (fn []
       [:div
        [:h4 {:class "content-title"}

--- a/src/com/yetanalytics/lrs_admin_ui/views/footer.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/footer.cljs
@@ -41,7 +41,7 @@
        [:div {:class "col-3 text-center footer-icon pointer"}
         [:a {:href "#"
              :on-click #(do (ps-event %)
-                            (dispatch-sync [:session/logout]))}
+                            (dispatch-sync [:logout/logout]))}
          [:i
           [:img {:src "images/icons/icon-mobile-logout.svg" :alt "Logout" :width "16"}]]
          [:span {:class "font-condensed font-10 fg-primary"} @(subscribe [:lang/get :footer.nav.logout])]]]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/header.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/header.cljs
@@ -28,5 +28,5 @@
            :href "#"
            :on-click (fn [e]
                        (fns/ps-event e)
-                       (dispatch-sync [:session/logout]))}
+                       (dispatch-sync [:logout/logout]))}
        @(subscribe [:lang/get :header.logout])]]]]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/reactions/template.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/reactions/template.cljs
@@ -42,7 +42,7 @@
 (defn var-gen
   []
   (let [open?     (r/atom false)
-        condition (r/atom "")
+        condition (r/atom "") ; TODO: Store in an app-db buffer
         path      (r/atom [""])]
     (fn []
       [:<>


### PR DESCRIPTION
Perform the following changes:
- [SQL-222] Call `/admin/account/logout` when logging out to revoke current JWT
- [SQL-263] Call `/admin/verify` before retrieving statement browser xAPI data
- [SQL-265] Call `/admin/account/renew` to extend user login time
- [SQL-266] Call `/admin/verify` upon init to ensure logout if backend has been reset
- [SQL-268] Automatically log the user out if inactive; also log out if JWT refresh expiry has been reached
- [SQL-273] Tested using proxy JWT and OIDC login; refactored handler namespace to separate out separate login paths

[SQL-222]: https://yet.atlassian.net/browse/SQL-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SQL-263]: https://yet.atlassian.net/browse/SQL-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SQL-265]: https://yet.atlassian.net/browse/SQL-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SQL-266]: https://yet.atlassian.net/browse/SQL-266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SQL-268]: https://yet.atlassian.net/browse/SQL-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SQL-273]: https://yet.atlassian.net/browse/SQL-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ