### PR TITLE
[SQL-271] Implement re-route routing

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,6 +12,7 @@
                                                  [cljsjs/oidc-client
                                                   reagent/reagent
                                                   re-frame/re-frame]}
+        com.yetanalytics/re-route               {:mvn/version "0.1.0"}
         com.yetanalytics/xapi-schema            {:mvn/version "1.2.3"}
         com.fasterxml.jackson.core/jackson-core {:mvn/version "2.11.4"}
         com.fasterxml.jackson.dataformat/jackson-dataformat-smile

--- a/resources/public/index_prod.html
+++ b/resources/public/index_prod.html
@@ -3,18 +3,18 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="apple-touch-icon" sizes="180x180" href="/admin/images/favicon/apple-touch-icon.png">
-        <link rel="icon" type="image/png" sizes="32x32" href="/admin/images/favicon/favicon-32x32.png">
-        <link rel="icon" type="image/png" sizes="16x16" href="/admin/images/favicon/favicon-16x16.png">
-        <link rel="manifest" href="/admin/images/favicon/site.webmanifest">
+        <link rel="apple-touch-icon" sizes="180x180" href="{{prefix}}/admin/images/favicon/apple-touch-icon.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{prefix}}/admin/images/favicon/favicon-32x32.png">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{prefix}}/admin/images/favicon/favicon-16x16.png">
+        <link rel="manifest" href="{{prefix}}/admin/images/favicon/site.webmanifest">
         <title>Yet Analytics LRS</title>
-        <link href="/admin/css/style.css" rel="stylesheet" type="text/css">
-        <link href="/admin/css/custom.css" rel="stylesheet" type="text/css">
+        <link href="{{prefix}}/admin/css/style.css" rel="stylesheet" type="text/css">
+        <link href="{{prefix}}/admin/css/custom.css" rel="stylesheet" type="text/css">
     </head>
     <body>
         <div id="app">
         </div>
-        <script src="/admin/main.js" type="text/javascript"></script>
+        <script src="{{prefix}}/admin/main.js" type="text/javascript"></script>
         <script type="text/javascript">
          //<![CDATA[
          com.yetanalytics.lrs_admin_ui.core.init();

--- a/src/com/yetanalytics/lrs_admin_ui/core.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/core.cljs
@@ -5,6 +5,8 @@
    [com.yetanalytics.lrs-admin-ui.subs]
    [com.yetanalytics.lrs-admin-ui.handlers]
    [re-frame.core :refer [dispatch-sync]]
+   [com.yetanalytics.re-route :as re-route]
+   [com.yetanalytics.lrs-admin-ui.routes :refer [routes]]
    [com.yetanalytics.lrs-admin-ui.views :as views]))
 
 (set! *warn-on-infer* true)
@@ -19,6 +21,7 @@
 
 (defn ^:export init [server-host]
   (dispatch-sync [:db/init server-host])
+  (dispatch-sync [::re-route/init routes :not-found {:enabled? false}])
   (mount-app-element))
 
 (defn ^:after-load on-reload []

--- a/src/com/yetanalytics/lrs_admin_ui/core.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/core.cljs
@@ -2,11 +2,9 @@
   (:require
    [goog.dom :as gdom]
    [reagent.dom :as rdom]
+   [re-frame.core :refer [dispatch-sync]]
    [com.yetanalytics.lrs-admin-ui.subs]
    [com.yetanalytics.lrs-admin-ui.handlers]
-   [re-frame.core :refer [dispatch-sync]]
-   [com.yetanalytics.re-route :as re-route]
-   [com.yetanalytics.lrs-admin-ui.routes :refer [routes]]
    [com.yetanalytics.lrs-admin-ui.views :as views]))
 
 (set! *warn-on-infer* true)
@@ -21,7 +19,6 @@
 
 (defn ^:export init [server-host]
   (dispatch-sync [:db/init server-host])
-  (dispatch-sync [::re-route/init routes :not-found {:enabled? false}])
   (mount-app-element))
 
 (defn ^:after-load on-reload []

--- a/src/com/yetanalytics/lrs_admin_ui/db.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/db.cljs
@@ -9,12 +9,10 @@
 ;; Spec to define the db
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(s/def :session/page keyword?)
 (s/def :session/token (s/nilable string?))
 (s/def :session/username (s/nilable string?))
 (s/def ::session
-  (s/keys :req-un [:session/page
-                   :session/token
+  (s/keys :req-un [:session/token
                    :session/username]))
 
 (s/def :login/username (s/nilable string?))

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -100,7 +100,8 @@
                        ?oidc             :oidc
                        ?oidc-local-admin :oidc-enable-local-admin
                        :as               env}]]
-   (let [routes (routes (select-keys env [:enable-admin-delete-actor
+   (let [routes (routes (select-keys env [:proxy-path
+                                          :enable-admin-delete-actor
                                           :enable-admin-status
                                           :enable-reactions]))]
      {:db (cond-> (assoc db

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -32,8 +32,7 @@
  :db/init
  global-interceptors
  (fn [_  [_ server-host]]
-   {:db {::db/session {:page :credentials
-                       :token (stor/get-item "lrs-jwt")
+   {:db {::db/session {:token (stor/get-item "lrs-jwt")
                        :username (stor/get-item "username")}
          ::db/login {:username nil
                      :password nil}
@@ -232,21 +231,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; General
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defmulti page-fx
-  "Given a set-page event query vector, adds any effects of moving to that page.
-  Note that you can use overloads beyond just the page keyword in your methods."
-  (fn [[_ page]]
-    page))
-
-(defmethod page-fx :default [_] [])
-
-(re-frame/reg-event-fx
- :session/set-page
- global-interceptors
- (fn [{:keys [db]} [_ page :as qvec]]
-   {:db (assoc-in db [::db/session :page] page)
-    :fx (page-fx qvec)}))
 
 (re-frame/reg-event-fx
  :server-error
@@ -899,24 +883,6 @@
          [:dispatch [:status/get-data ["timeline"]]]
          [:dispatch [:status/get-data ["platform-frequency"]]]]}))
 
-(def status-dispatch-all
-  (into []
-        (for [status-query ["statement-count"
-                            "actor-count"
-                            "last-statement-stored"
-                            "timeline"
-                            "platform-frequency"]]
-          [:dispatch [:status/get-data [status-query]]])))
-
-(defmethod page-fx :status [_]
-  status-dispatch-all)
-
-(re-frame/reg-event-fx
- :status/get-all-data
- global-interceptors
- (fn [_ _]
-   {:fx status-dispatch-all}))
-
 (defn- coerce-status-data
   "Convert string keys in status data to keyword where appropriate."
   [status-data]
@@ -1000,10 +966,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Reaction Management
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defmethod page-fx :reactions [_]
-  [[:dispatch [:reaction/back-to-list]]
-   [:dispatch [:reaction/load-reactions]]])
 
 (re-frame/reg-event-fx
  :reaction/load-reactions

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.lrs-admin-ui.handlers
   (:require [re-frame.core                                    :as re-frame]
             [reagent.core                                     :as r]
+            [com.yetanalytics.re-route                        :as re-route]
             [com.yetanalytics.lrs-admin-ui.db                 :as db]
             [com.yetanalytics.lrs-admin-ui.input              :as input]
             [day8.re-frame.http-fx]
@@ -750,7 +751,7 @@
  global-interceptors
  (fn [_ _]
    {:fx [[:dispatch [:update-password/clear]]
-         [:dispatch [:session/set-page :credentials]]
+         [:dispatch [::re-route/navigate :credentials]]
          [:dispatch [:notification/notify false
                      "Password updated."]]]}))
 

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -176,7 +176,6 @@
    ;; incongrous mix of authentication procedures.
    (let [curr-token (stor/get-item "lrs-jwt")
          curr-uname (stor/get-item "username")]
-     (println "Current token:" curr-token)
      (if (some? curr-token)
        {:http-xhrio
         {:method          :get

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -127,10 +127,11 @@
                        ?oidc        :oidc
                        ?oidc-enable :oidc-enable-local-admin
                        :as          env}]]
-   (let [routes (routes (select-keys env [:proxy-path
-                                          :enable-admin-delete-actor
-                                          :enable-admin-status
-                                          :enable-reactions]))
+   (let [ui-route-env             (select-keys env [:proxy-path
+                                                    :enable-admin-delete-actor
+                                                    :enable-admin-status
+                                                    :enable-reactions])
+         ui-routes                (routes ui-route-env)
          jwt-refresh-interval*    (* 1000 jwt-refresh-interval)
          jwt-interaction-window*  (* 1000 jwt-interaction-window)
          oidc-enable-local-admin? (or ?oidc-enable false)
@@ -155,7 +156,7 @@
                  (not-empty no-val-logout-url))
             (assoc ::db/no-val-logout-url no-val-logout-url))
       :fx (cond-> [[:dispatch [::re-route/init
-                               routes
+                               ui-routes
                                :not-found
                                {:enabled? false}]]]
             ?oidc   (conj [:dispatch [:oidc/init ?oidc]])

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.lrs-admin-ui.handlers
   (:require [re-frame.core                                    :as re-frame]
             [reagent.core                                     :as r]
+            [com.yetanalytics.re-route                        :as re-route]
             [com.yetanalytics.lrs-admin-ui.db                 :as db]
             [com.yetanalytics.lrs-admin-ui.input              :as input]
             [day8.re-frame.http-fx]
@@ -22,6 +23,7 @@
             [com.yetanalytics.lrs-admin-ui.spec.reaction      :as rs]
             [com.yetanalytics.lrs-admin-ui.spec.reaction-edit :as rse]
             [com.yetanalytics.lrs-admin-ui.language           :as lang]
+            [com.yetanalytics.lrs-admin-ui.routes             :refer [routes]]
             [com.yetanalytics.lrs-reactions.path              :as rpath]))
 
 (def global-interceptors
@@ -62,7 +64,8 @@
          ::db/status {}
          ::db/enable-reactions false
          ::db/reactions []}
-    :fx [[:dispatch [:db/get-env]]]}))
+    :fx [[:dispatch [::re-route/init routes :not-found {:enabled? false}]]
+         [:dispatch [:db/get-env]]]}))
 
 (re-frame/reg-event-fx
  :db/get-env

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -890,6 +890,15 @@
     :fx [[:dispatch
           [:server-error error]]]}))
 
+(re-frame/reg-event-fx
+ :status/get-all-data
+ (fn [_]
+   {:fx [[:dispatch [:status/get-data ["statement-count"]]]
+         [:dispatch [:status/get-data ["actor-count"]]]
+         [:dispatch [:status/get-data ["last-statement-stored"]]]
+         [:dispatch [:status/get-data ["timeline"]]]
+         [:dispatch [:status/get-data ["platform-frequency"]]]]}))
+
 (def status-dispatch-all
   (into []
         (for [status-query ["statement-count"

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -125,7 +125,8 @@
                                      stmt-get-max
                                      custom-language]
                        ?oidc        :oidc
-                       ?oidc-enable :oidc-enable-local-admin}]]
+                       ?oidc-enable :oidc-enable-local-admin
+                       :as          env}]]
    (let [routes (routes (select-keys env [:proxy-path
                                           :enable-admin-delete-actor
                                           :enable-admin-status
@@ -148,10 +149,8 @@
                          ::db/enable-reactions enable-reactions
                          ::db/enable-admin-delete-actor enable-admin-delete-actor
                          ::db/stmt-get-max stmt-get-max
-                         ::db/pref-lang (keyword admin-language-code)
-                         ::db/language (merge-with merge
-                                                   lang/language
-                                                   custom-language))
+                         ::db/pref-lang admin-lang-keyword
+                         ::db/language language-map)
             (and no-val?
                  (not-empty no-val-logout-url))
             (assoc ::db/no-val-logout-url no-val-logout-url))

--- a/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/handlers.cljs
@@ -1,7 +1,6 @@
 (ns com.yetanalytics.lrs-admin-ui.handlers
   (:require [re-frame.core                                    :as re-frame]
             [reagent.core                                     :as r]
-            [com.yetanalytics.re-route                        :as re-route]
             [com.yetanalytics.lrs-admin-ui.db                 :as db]
             [com.yetanalytics.lrs-admin-ui.input              :as input]
             [day8.re-frame.http-fx]
@@ -23,7 +22,6 @@
             [com.yetanalytics.lrs-admin-ui.spec.reaction      :as rs]
             [com.yetanalytics.lrs-admin-ui.spec.reaction-edit :as rse]
             [com.yetanalytics.lrs-admin-ui.language           :as lang]
-            [com.yetanalytics.lrs-admin-ui.routes             :refer [routes]]
             [com.yetanalytics.lrs-reactions.path              :as rpath]))
 
 (def global-interceptors
@@ -64,8 +62,7 @@
          ::db/status {}
          ::db/enable-reactions false
          ::db/reactions []}
-    :fx [[:dispatch [::re-route/init routes :not-found {:enabled? false}]]
-         [:dispatch [:db/get-env]]]}))
+    :fx [[:dispatch [:db/get-env]]]}))
 
 (re-frame/reg-event-fx
  :db/get-env

--- a/src/com/yetanalytics/lrs_admin_ui/language.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/language.cljs
@@ -19,6 +19,9 @@
    :header.nav.monitor     {:en-US "LRS Monitor"}
    :header.nav.data        {:en-US "Data Management"}
    :header.nav.reactions   {:en-US "Reactions"}
+   ;;404 Page
+   :not-found.title {:en-US "404 Not Found"}
+   :not-found.body  {:en-US "The page that you are looking for cannot be found."}
    ;;Login Page
    :login.title        {:en-US "LOGIN"}
    :login.username     {:en-US "Username"}

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -19,22 +19,16 @@
    ["/credentials"
     {:name        :credentials
      :view        credentials
-     :controllers [{:identity (fn [_] nil)
-                    :stop     (fn [_] nil)
-                    :start    (fn [_]
-                                (dispatch [:credentials/load-credentials]))}]}]
+     :controllers [{:start (fn [_]
+                             (dispatch [:credentials/load-credentials]))}]}]
    ["/accounts"
     {:name        :accounts
      :view        accounts
-     :controllers [{:identity (fn [_] nil)
-                    :stop     (fn [_] nil)
-                    :start    (fn [_] (dispatch [:accounts/load-accounts]))}]}]
+     :controllers [{:start (fn [_] (dispatch [:accounts/load-accounts]))}]}]
    ["/password"
     {:name        :update-password
      :view        update-password
-     :controllers [{:identity (fn [_] nil)
-                    :stop     (fn [_] nil)
-                    :start    (fn [_] (dispatch [:update-password/clear]))}]}]
+     :controllers [{:stop (fn [_] (dispatch [:update-password/clear]))}]}]
    ["/browser"
     {:name :browser
      :view browser}]

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -1,6 +1,8 @@
 (ns com.yetanalytics.lrs-admin-ui.routes
   (:require
    [re-frame.core :refer [dispatch]]
+   [reitit.core :as r]
+   [reitit.frontend :as rf]
    [com.yetanalytics.lrs-admin-ui.views.accounts        :refer [accounts]]
    [com.yetanalytics.lrs-admin-ui.views.browser         :refer [browser]]
    [com.yetanalytics.lrs-admin-ui.views.credentials     :refer [credentials]]
@@ -14,14 +16,22 @@
   [["/credentials"
     {:name        :credentials
      :view        credentials
-     :controllers [{:start (fn [_] (dispatch [:credentials/load-credentials]))}]}]
+     :controllers [{:identity (fn [_] nil)
+                    :stop     (fn [_] nil)
+                    :start    (fn [_]
+                                (dispatch [:credentials/load-credentials]))}]}]
    ["/accounts"
     {:name        :accounts
      :view        accounts
-     :controllers [{:start (fn [_] (dispatch [:accounts/load-accounts]))}]}]
+     :controllers [{:identity (fn [_] nil)
+                    :stop     (fn [_] nil)
+                    :start    (fn [_] (dispatch [:accounts/load-accounts]))}]}]
    ["/password"
-    {:name :update-password
-     :view update-password}]
+    {:name        :update-password
+     :view        update-password
+     :controllers [{:identity (fn [_] nil)
+                    :stop     (fn [_] nil)
+                    :start    (fn [_] (dispatch [:update-password/clear]))}]}]
    ["/browser"
     {:name :browser
      :view browser}]
@@ -31,21 +41,22 @@
    ["/status"
     {:name        :status
      :view        status
-     :controllers [{:start
-                    (fn [_]
-                      (dispatch [:status/get-data "statement-count"])
-                      (dispatch [:status/get-data "actor-count"])
-                      (dispatch [:status/get-data "last-statement-stored"])
-                      (dispatch [:status/get-data "timeline"])
-                      (dispatch [:status/get-data "platform-frequency"]))}]}]
+     :controllers [{:identity (fn [_] nil)
+                    :stop     (fn [_] nil)
+                    :start    (fn [_]
+                                (dispatch [:status/get-data ["statement-count"]])
+                                (dispatch [:status/get-data ["actor-count"]])
+                                (dispatch [:status/get-data ["last-statement-stored"]])
+                                (dispatch [:status/get-data ["timeline"]])
+                                (dispatch [:status/get-data ["platform-frequency"]]))}]}]
    ["/reactions"
     {:name        :reactions
      :view        reactions
-     :parameters  {}
-     :controllers [{:start
-                    (fn [_]
-                      (dispatch [:reaction/back-to-list])
-                      (dispatch [:reaction/load-reactions]))}]}]
+     :controllers [{:identity (fn [_] nil)
+                    :stop     (fn [_] nil)
+                    :start    (fn [_]
+                                (dispatch [:reaction/back-to-list])
+                                (dispatch [:reaction/load-reactions]))}]}]
    ["/not-found"
     {:name :not-found
      :view not-found}]])

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -11,7 +11,8 @@
    [com.yetanalytics.lrs-admin-ui.views.update-password :refer [update-password]]))
 
 (def routes
-  [["/"
+  ["/ui"
+   [""
     {:name        :home
      :view        credentials
      :controllers [{:start (fn [_]

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -26,7 +26,7 @@
      :view        accounts
      :controllers [{:start (fn [_]
                              (dispatch [:accounts/load-accounts]))}]}]
-   ["/password"
+   ["/accounts/password"
     {:name        :update-password
      :view        update-password
      :controllers [{:stop (fn [_]

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -55,6 +55,8 @@
             :controllers [{:start
                            (fn [_]
                              (dispatch [:status/get-all-data]))}]}])
+    ;; TODO: Add `/reactions/new`, `/reactions/view`, and `/reactions/edit`
+    ;; routes for their respective pages.
     enable-reactions
     (conj ["/reactions"
            {:name        :reactions

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -1,8 +1,6 @@
 (ns com.yetanalytics.lrs-admin-ui.routes
   (:require
    [re-frame.core :refer [dispatch]]
-   [reitit.core :as r]
-   [reitit.frontend :as rf]
    [com.yetanalytics.lrs-admin-ui.views.accounts        :refer [accounts]]
    [com.yetanalytics.lrs-admin-ui.views.browser         :refer [browser]]
    [com.yetanalytics.lrs-admin-ui.views.credentials     :refer [credentials]]
@@ -13,7 +11,12 @@
    [com.yetanalytics.lrs-admin-ui.views.update-password :refer [update-password]]))
 
 (def routes
-  [["/credentials"
+  [["/"
+    {:name        :home
+     :view        credentials
+     :controllers [{:start (fn [_]
+                             (dispatch [:credentials/load-credentials]))}]}]
+   ["/credentials"
     {:name        :credentials
      :view        credentials
      :controllers [{:identity (fn [_] nil)

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -10,45 +10,56 @@
    [com.yetanalytics.lrs-admin-ui.views.status          :refer [status]]
    [com.yetanalytics.lrs-admin-ui.views.update-password :refer [update-password]]))
 
-(def routes
-  ["/admin/ui"
-   [""
-    {:name        :home
-     :view        credentials
-     :controllers [{:start (fn [_]
-                             (dispatch [:credentials/load-credentials]))}]}]
-   ["/credentials"
-    {:name        :credentials
-     :view        credentials
-     :controllers [{:start (fn [_]
-                             (dispatch [:credentials/load-credentials]))}]}]
-   ["/accounts"
-    {:name        :accounts
-     :view        accounts
-     :controllers [{:start (fn [_]
-                             (dispatch [:accounts/load-accounts]))}]}]
-   ["/accounts/password"
-    {:name        :update-password
-     :view        update-password
-     :controllers [{:stop (fn [_]
-                            (dispatch [:update-password/clear]))}]}]
-   ["/browser"
-    {:name :browser
-     :view browser}]
-   ["/data-management"
-    {:name :data-management
-     :view data-management}]
-   ["/status"
-    {:name        :status
-     :view        status
-     :controllers [{:start (fn [_]
-                             (dispatch [:status/get-all-data]))}]}]
-   ["/reactions"
-    {:name        :reactions
-     :view        reactions
-     :controllers [{:start (fn [_]
+(defn routes [{:keys [enable-admin-delete-actor
+                      enable-admin-status
+                      enable-reactions]}]
+  (cond-> ["/admin/ui"
+           [""
+            {:name        :home
+             :view        credentials
+             :controllers [{:start
+                            (fn [_]
+                              (dispatch [:credentials/load-credentials]))}]}]
+           ["/credentials"
+            {:name        :credentials
+             :view        credentials
+             :controllers [{:start
+                            (fn [_]
+                              (dispatch [:credentials/load-credentials]))}]}]
+           ["/accounts"
+            {:name        :accounts
+             :view        accounts
+             :controllers [{:start
+                            (fn [_]
+                              (dispatch [:accounts/load-accounts]))}]}]
+           ["/accounts/password"
+            {:name        :update-password
+             :view        update-password
+             :controllers [{:stop
+                            (fn [_]
+                              (dispatch [:update-password/clear]))}]}]
+           ["/browser"
+            {:name :browser
+             :view browser}]
+           ["/not-found"
+            {:name :not-found
+             :view not-found}]]
+    enable-admin-delete-actor
+    (conj ["/data-management"
+           {:name :data-management
+            :view data-management}])
+    enable-admin-status
+    (conj ["/status"
+           {:name        :status
+            :view        status
+            :controllers [{:start
+                           (fn [_]
+                             (dispatch [:status/get-all-data]))}]}])
+    enable-reactions
+    (conj ["/reactions"
+           {:name        :reactions
+            :view        reactions
+            :controllers [{:start
+                           (fn [_]
                              (dispatch [:reaction/back-to-list])
-                             (dispatch [:reaction/load-reactions]))}]}]
-   ["/not-found"
-    {:name :not-found
-     :view not-found}]])
+                             (dispatch [:reaction/load-reactions]))}]}])))

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -11,7 +11,7 @@
    [com.yetanalytics.lrs-admin-ui.views.update-password :refer [update-password]]))
 
 (def routes
-  ["/ui"
+  ["/admin/ui"
    [""
     {:name        :home
      :view        credentials

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -24,11 +24,13 @@
    ["/accounts"
     {:name        :accounts
      :view        accounts
-     :controllers [{:start (fn [_] (dispatch [:accounts/load-accounts]))}]}]
+     :controllers [{:start (fn [_]
+                             (dispatch [:accounts/load-accounts]))}]}]
    ["/password"
     {:name        :update-password
      :view        update-password
-     :controllers [{:stop (fn [_] (dispatch [:update-password/clear]))}]}]
+     :controllers [{:stop (fn [_]
+                            (dispatch [:update-password/clear]))}]}]
    ["/browser"
     {:name :browser
      :view browser}]
@@ -38,22 +40,14 @@
    ["/status"
     {:name        :status
      :view        status
-     :controllers [{:identity (fn [_] nil)
-                    :stop     (fn [_] nil)
-                    :start    (fn [_]
-                                (dispatch [:status/get-data ["statement-count"]])
-                                (dispatch [:status/get-data ["actor-count"]])
-                                (dispatch [:status/get-data ["last-statement-stored"]])
-                                (dispatch [:status/get-data ["timeline"]])
-                                (dispatch [:status/get-data ["platform-frequency"]]))}]}]
+     :controllers [{:start (fn [_]
+                             (dispatch [:status/get-all-data]))}]}]
    ["/reactions"
     {:name        :reactions
      :view        reactions
-     :controllers [{:identity (fn [_] nil)
-                    :stop     (fn [_] nil)
-                    :start    (fn [_]
-                                (dispatch [:reaction/back-to-list])
-                                (dispatch [:reaction/load-reactions]))}]}]
+     :controllers [{:start (fn [_]
+                             (dispatch [:reaction/back-to-list])
+                             (dispatch [:reaction/load-reactions]))}]}]
    ["/not-found"
     {:name :not-found
      :view not-found}]])

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -1,0 +1,51 @@
+(ns com.yetanalytics.lrs-admin-ui.routes
+  (:require
+   [re-frame.core :refer [dispatch]]
+   [com.yetanalytics.lrs-admin-ui.views.accounts        :refer [accounts]]
+   [com.yetanalytics.lrs-admin-ui.views.browser         :refer [browser]]
+   [com.yetanalytics.lrs-admin-ui.views.credentials     :refer [credentials]]
+   [com.yetanalytics.lrs-admin-ui.views.data-management :refer [data-management]]
+   [com.yetanalytics.lrs-admin-ui.views.not-found       :refer [not-found]]
+   [com.yetanalytics.lrs-admin-ui.views.reactions       :refer [reactions]]
+   [com.yetanalytics.lrs-admin-ui.views.status          :refer [status]]
+   [com.yetanalytics.lrs-admin-ui.views.update-password :refer [update-password]]))
+
+(def routes
+  [["/credentials"
+    {:name        :credentials
+     :view        credentials
+     :controllers [{:start (fn [_] (dispatch [:credentials/load-credentials]))}]}]
+   ["/accounts"
+    {:name        :accounts
+     :view        accounts
+     :controllers [{:start (fn [_] (dispatch [:accounts/load-accounts]))}]}]
+   ["/password"
+    {:name :update-password
+     :view update-password}]
+   ["/browser"
+    {:name :browser
+     :view browser}]
+   ["/data-management"
+    {:name :data-management
+     :view data-management}]
+   ["/status"
+    {:name        :status
+     :view        status
+     :controllers [{:start
+                    (fn [_]
+                      (dispatch [:status/get-data "statement-count"])
+                      (dispatch [:status/get-data "actor-count"])
+                      (dispatch [:status/get-data "last-statement-stored"])
+                      (dispatch [:status/get-data "timeline"])
+                      (dispatch [:status/get-data "platform-frequency"]))}]}]
+   ["/reactions"
+    {:name        :reactions
+     :view        reactions
+     :parameters  {}
+     :controllers [{:start
+                    (fn [_]
+                      (dispatch [:reaction/back-to-list])
+                      (dispatch [:reaction/load-reactions]))}]}]
+   ["/not-found"
+    {:name :not-found
+     :view not-found}]])

--- a/src/com/yetanalytics/lrs_admin_ui/routes.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/routes.cljs
@@ -10,10 +10,11 @@
    [com.yetanalytics.lrs-admin-ui.views.status          :refer [status]]
    [com.yetanalytics.lrs-admin-ui.views.update-password :refer [update-password]]))
 
-(defn routes [{:keys [enable-admin-delete-actor
+(defn routes [{:keys [proxy-path
+                      enable-admin-delete-actor
                       enable-admin-status
                       enable-reactions]}]
-  (cond-> ["/admin/ui"
+  (cond-> [(str proxy-path "/admin/ui")
            [""
             {:name        :home
              :view        credentials

--- a/src/com/yetanalytics/lrs_admin_ui/subs.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/subs.cljs
@@ -48,13 +48,6 @@
          (get langmap (-> langmap keys first))))))
 
 (reg-sub
- :session/get-page
- (fn [_ _]
-   (subscribe [:db/get-session]))
- (fn [session _]
-   (:page session)))
-
-(reg-sub
  :session/get-token
  (fn [_ _]
    (subscribe [:db/get-session]))

--- a/src/com/yetanalytics/lrs_admin_ui/subs.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/subs.cljs
@@ -29,15 +29,17 @@
 
 (reg-sub
  :resources/image
+ :<- [::db/proxy-path]
  :<- [::db/resource-base]
- (fn [resource-base [_ image-name]]
-   (str resource-base "images/" image-name)))
+ (fn [[proxy-path resource-base] [_ image-name]]
+   (str proxy-path resource-base "images/" image-name)))
 
 (reg-sub
  :resources/icon
+ :<- [::db/proxy-path]
  :<- [::db/resource-base]
- (fn [resource-base [_ icon-name]]
-   (str resource-base "images/icons/" icon-name)))
+ (fn [[proxy-path resource-base] [_ icon-name]]
+   (str proxy-path resource-base "images/icons/" icon-name)))
 
 (reg-sub
  :db/language

--- a/src/com/yetanalytics/lrs_admin_ui/views.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views.cljs
@@ -1,6 +1,7 @@
 (ns ^:figwheel-hooks com.yetanalytics.lrs-admin-ui.views
   (:require
    [re-frame.core :refer [subscribe]]
+   [com.yetanalytics.re-route :as re-route]
    [com.yetanalytics.lrs-admin-ui.views.header :refer [header]]
    [com.yetanalytics.lrs-admin-ui.views.main :refer [main]]
    [com.yetanalytics.lrs-admin-ui.views.footer :refer [footer]]
@@ -9,8 +10,11 @@
    [com.yetanalytics.lrs-admin-ui.views.dialog :as dialog]))
 
 (defn app []
-  (let [token @(subscribe [:session/get-token])]
+  (let [token @(subscribe [:session/get-token])
+        route @(subscribe [::re-route/route])]
     (cond
+      (= route nil)
+      nil
       (= token nil)
       [:div
        [notifications]

--- a/src/com/yetanalytics/lrs_admin_ui/views/accounts.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/accounts.cljs
@@ -2,6 +2,7 @@
   (:require
    [reagent.core :as r]
    [re-frame.core :refer [subscribe dispatch]]
+   [com.yetanalytics.re-route :as re-route]
    [com.yetanalytics.lrs-admin-ui.functions :as fns]
    [com.yetanalytics.lrs-admin-ui.functions.copy :refer [copy-text]]
    [com.yetanalytics.lrs-admin-ui.input :refer [p-min-len u-min-len]]
@@ -39,10 +40,7 @@
                @(subscribe [:lang/get :accounts.delete])]])
            (when (= username current-username)
              [:li
-              [:a {:href "#!"
-                   :on-click (fn [e]
-                               (fns/ps-event e)
-                               (dispatch [:session/set-page :update-password]))
+              [:a {:href @(subscribe [::re-route/href :update-password])
                    :class "icon-edit"}
                @(subscribe [:lang/get :accounts.password.update])]])]]]]])))
 

--- a/src/com/yetanalytics/lrs_admin_ui/views/accounts.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/accounts.cljs
@@ -94,7 +94,6 @@
                  :class "icon-gen"} [:i @(subscribe [:lang/get :accounts.new.password.generate])]]]]]]))))
 
 (defn accounts []
-  (dispatch [:accounts/load-accounts])
   (let [accounts @(subscribe [:db/get-accounts])]
     [:div {:class "left-content-wrapper"}
      [:h2 {:class "content-title"}

--- a/src/com/yetanalytics/lrs_admin_ui/views/credentials.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/credentials.cljs
@@ -1,10 +1,9 @@
 (ns com.yetanalytics.lrs-admin-ui.views.credentials
   (:require
-   [re-frame.core :refer [dispatch subscribe]]
+   [re-frame.core :refer [subscribe]]
    [com.yetanalytics.lrs-admin-ui.views.credentials.tenant :refer [tenant]]))
 
 (defn credentials []
-  (dispatch [:credentials/load-credentials])
   [:div {:class "left-content-wrapper"}
    [:h2 {:class "content-title"}
     @(subscribe [:lang/get :credentials.title])]

--- a/src/com/yetanalytics/lrs_admin_ui/views/footer.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/footer.cljs
@@ -1,5 +1,6 @@
 (ns com.yetanalytics.lrs-admin-ui.views.footer
   (:require [com.yetanalytics.lrs-admin-ui.functions :refer [ps-event]]
+            [com.yetanalytics.re-route :as re-route]
             [re-frame.core :refer [subscribe dispatch-sync]]
             [goog.string   :refer [format unescapeEntities]]
             goog.string.format))
@@ -19,22 +20,20 @@
   [:div {:class "mobile-footer"}
    [:div {:class "footer-menu-box"}
     (when (not= nil @(subscribe [:session/get-token]))
+      ;; TODO: All menu items, including LRS monitor, data mgmt, and reactions
       [:div {:class "row no-gutters"}
        [:div {:class "col-3 text-center footer-icon pointer"}
-        [:a {:href "#"
-             :on-click #(dispatch-sync [:session/set-page :credentials])}
+        [:a {:href @(subscribe [::re-route/href :credentials])}
          [:i
           [:img {:src "images/icons/icon-mobile-credentials.svg" :alt "" :width "16"}]]
          [:span {:class "font-condensed font-10 fg-primary"} @(subscribe [:lang/get :footer.nav.credentials])]]]
        [:div {:class "col-3 text-center footer-icon pointer"}
-        [:a {:href "#"
-             :on-click #(dispatch-sync [:session/set-page :accounts])}
+        [:a {:href @(subscribe [::re-route/href :accounts])}
          [:i
           [:img {:src "images/icons/icon-mobile-profle.svg" :alt "" :width "10"}]]
          [:span {:class "font-condensed font-10 fg-primary"} @(subscribe [:lang/get :footer.nav.accounts])]]]
        [:div {:class "col-3 text-center footer-icon pointer"}
-        [:a {:href "#"
-             :on-click #(dispatch-sync [:session/set-page :browser])}
+        [:a {:href @(subscribe [::re-route/href :browser])}
          [:i
           [:img {:src "images/icons/icon-mobile-search.svg" :alt "" :width "16"}]]
          [:span {:class "font-condensed font-10 fg-primary"} @(subscribe [:lang/get :footer.nav.browser])]]]

--- a/src/com/yetanalytics/lrs_admin_ui/views/header.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/header.cljs
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.lrs-admin-ui.views.header
   (:require [com.yetanalytics.lrs-admin-ui.functions :as fns]
-            [re-frame.core :refer [subscribe dispatch dispatch-sync]]))
+            [com.yetanalytics.re-route :as re-route]
+            [re-frame.core :refer [subscribe dispatch-sync]]))
 
 (defn username []
   (let [display-name @(subscribe [:session/get-display-name])]
@@ -9,10 +10,7 @@
      (if @(subscribe [:oidc/enabled?])
        [:span display-name]
        [:a {:class "fg-primary"
-            :href "#"
-            :on-click (fn [e]
-                        (fns/ps-event e)
-                        (dispatch [:session/set-page :update-password]))}
+            :href @(subscribe [::re-route/href :update-password])}
         display-name])]))
 
 (defn header []

--- a/src/com/yetanalytics/lrs_admin_ui/views/main.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/main.cljs
@@ -1,14 +1,8 @@
 (ns com.yetanalytics.lrs-admin-ui.views.main
   (:require
    [re-frame.core :refer [subscribe]]
-   [com.yetanalytics.lrs-admin-ui.views.credentials :refer [credentials]]
-   [com.yetanalytics.lrs-admin-ui.views.browser :refer [browser]]
-   [com.yetanalytics.lrs-admin-ui.views.menu :refer [menu]]
-   [com.yetanalytics.lrs-admin-ui.views.accounts :refer [accounts]]
-   [com.yetanalytics.lrs-admin-ui.views.status :refer [status]]
-   [com.yetanalytics.lrs-admin-ui.views.update-password :refer [update-password]]
-   [com.yetanalytics.lrs-admin-ui.views.data-management :refer [data-management]]
-   [com.yetanalytics.lrs-admin-ui.views.reactions :refer [reactions]]))
+   [com.yetanalytics.re-route :as re-route]
+   [com.yetanalytics.lrs-admin-ui.views.menu :refer [menu]]))
 
 (defn main []
   [:main {:class "lrs-main"}
@@ -16,12 +10,6 @@
    [menu]
    [:div {:class "row no-gutters"}
     [:div {:class "main-sections"}
-     (case @(subscribe [:session/get-page])
-       :credentials [credentials]
-       :browser [browser]
-       :accounts [accounts]
-       :status [status]
-       :update-password [update-password]
-       :data-management [data-management]
-       :reactions [reactions])]
+     (when-some [page @(subscribe [::re-route/route-view])]
+       [page])]
     [:div {:class "content-right-wrapper"}]]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/menu.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/menu.cljs
@@ -1,13 +1,14 @@
 (ns com.yetanalytics.lrs-admin-ui.views.menu
   (:require
-   [re-frame.core :refer [subscribe dispatch-sync]]))
+   [re-frame.core :refer [subscribe]]
+   [com.yetanalytics.re-route :as re-route]))
 
 (defn menu-item
   [{:keys [name page]}]
   [:li {:class "banner-link-item"}
-   [:a (cond-> {:href "#"
-                :on-click #(dispatch-sync [:session/set-page page])}
-         (= page @(subscribe [:session/get-page])) (merge {:class "active"}))
+   [:a (cond-> {:href @(subscribe [::re-route/href page])}
+         (= page @(subscribe [::re-route/route-name]))
+         (merge {:class "active"}))
     name]])
 
 (defn menu []

--- a/src/com/yetanalytics/lrs_admin_ui/views/not_found.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/not_found.cljs
@@ -1,4 +1,8 @@
-(ns com.yetanalytics.lrs-admin-ui.views.not-found)
+(ns com.yetanalytics.lrs-admin-ui.views.not-found
+  (:require [re-frame.core :refer [subscribe]]))
 
 (defn not-found []
-  [:h1 "404: Not Found!"])
+  [:div {:class "left-content-wrapper"}
+   [:h2 {:class "content-title"}
+    @(subscribe [:lang/get :not-found.title])]
+   [:p @(subscribe [:lang/get :not-found.body])]])

--- a/src/com/yetanalytics/lrs_admin_ui/views/not_found.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/not_found.cljs
@@ -1,0 +1,4 @@
+(ns com.yetanalytics.lrs-admin-ui.views.not-found)
+
+(defn not-found []
+  [:h1 "404: Not Found!"])

--- a/src/com/yetanalytics/lrs_admin_ui/views/update_password.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/update_password.cljs
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.lrs-admin-ui.views.update-password
   (:require [reagent.core :as r]
             [re-frame.core :refer [subscribe dispatch]]
+            [com.yetanalytics.re-route :as re-route]
             [com.yetanalytics.lrs-admin-ui.functions :as fns]
             [com.yetanalytics.lrs-admin-ui.functions.copy :refer [copy-text]]
             [com.yetanalytics.lrs-admin-ui.functions.password :as pass]
@@ -69,7 +70,7 @@
    [:div {:class "update-password-actions"}
     [:input {:type "button",
              :class "btn-brand-bold",
-             :on-click #(dispatch [:session/set-page :accounts])
+             :on-click #(dispatch [::re-route/navigate :accounts])
              :value @(subscribe [:lang/get :account-mgmt.update-password.cancel])}]
     [:input {:type "button",
              :class "btn-brand-bold",

--- a/src/com/yetanalytics/lrs_admin_ui/views/update_password.cljs
+++ b/src/com/yetanalytics/lrs_admin_ui/views/update_password.cljs
@@ -10,7 +10,6 @@
             goog.string.format))
 
 (defn form []
-  (dispatch [:update-password/clear])
   (let [hide-pass (r/atom true)]
     (fn []
       (let [new-password @(subscribe [:update-password/new-password])]


### PR DESCRIPTION
Same commits as #92 but now excluding changes to SPA base paths.

Implement re-route, including a route map, handlers, and subs, to allow for separate paths such as `/admin/ui/credentials` or `/admin/ui/accounts/password`.