### PR TITLE
create local datetimes with dynamic offset

### DIFF
--- a/test/com/yetanalytics/lrs_admin_ui/functions/time_test.cljs
+++ b/test/com/yetanalytics/lrs_admin_ui/functions/time_test.cljs
@@ -1,0 +1,20 @@
+(ns com.yetanalytics.lrs-admin-ui.functions.time-test
+  (:require [clojure.test :refer-macros [deftest is testing]]
+            [com.yetanalytics.lrs-admin-ui.functions.time
+             :refer [tz-offset-mins*
+                     utc->local-datetime]]))
+
+(deftest tz-offset-mins*-test
+  (testing "yields different offsets for different dates"
+    (is (not=
+         (tz-offset-mins* (new js/Date "2025-03-04T00:00:00Z"))
+         (tz-offset-mins* (new js/Date "2025-03-19T00:00:00Z"))))))
+
+(deftest utc->local-datetime-test
+  (testing "derives timezone offset appropriate to the passed-in date"
+    (is (= "2025-03-04T14:48:53"
+           (utc->local-datetime "2025-03-04T19:48:53Z"
+                                :tz-offset-mins 300)))
+    (is (= "2025-03-19T15:48:53"
+           (utc->local-datetime "2025-03-19T19:48:53Z"
+                                :tz-offset-mins 240)))))

--- a/test/com/yetanalytics/lrs_admin_ui/test_runner.cljs
+++ b/test/com/yetanalytics/lrs_admin_ui/test_runner.cljs
@@ -5,6 +5,7 @@
    #_clojure.test.check.properties
    ;; require all the namespaces that you want to test
    [com.yetanalytics.lrs-admin-ui.functions.reaction-test]
+   [com.yetanalytics.lrs-admin-ui.functions.time-test]
    [figwheel.main.testing :refer-macros [run-tests-async]]))
 
 (defn -main [& args]


### PR DESCRIPTION
local datetime string creation functions were basing the offset on the current date, not the date passed in. This fixes that and adds a test for it.